### PR TITLE
Fix for the Fortran 2003 bindings generator

### DIFF
--- a/bindings/bindings_generator/fortran03_generator.py
+++ b/bindings/bindings_generator/fortran03_generator.py
@@ -402,7 +402,7 @@ end type
                     pre += 2*indent + '%s = C_NULL_PTR\n' % var
                     post = 2*indent + 'call c_f_strarrayptr(size(%s),%s, %s)\n' % (arg_dec.name, var, arg_dec.name)
                 else:
-                    pre = None
+                    pre = 2*indent + '%s = C_NULL_PTR\n' % var
                     post = 2*indent + 'call c_f_stringptr(%s, %s)\n' % (var, arg_dec.name)
             else:
                 if arg_dec.arrayinfos['is_array']:
@@ -491,7 +491,7 @@ end type
                         else:
                             string = 'character(kind=C_CHAR), intent(in) :: %s(*)' % arg_name
                     else:
-                        string = 'type(C_PTR) :: %s = C_NULL_PTR' % arg_name
+                        string = 'type(C_PTR) :: %s' % arg_name
                 else: #language_binding == 'F'
                     if function_result or arg_dec.is_outarg:
                         string = 'character(kind=C_CHAR), pointer :: %s(:)' % arg_name


### PR DESCRIPTION
This replaces the following code in variable/argument wrappers
```
  type(C_PTR) :: myArg_c = C_NULL_PTR
```
by
```
  type(C_PTR) :: myArg_c

  myArg_c = C_NULL_PTR
```

The background is that in the first form the compiler assumes the SAVE
property for the variable (e.g. static in C/C++). Thus this might only
work correctly once!