### PR TITLE
For XML Schema validation fill out default values

### DIFF
--- a/bindings/fortran/tixi77.c
+++ b/bindings/fortran/tixi77.c
@@ -235,6 +235,17 @@ void tixiSchemaValidateFromFile_f(const TixiDocumentHandle *handle,
   free(cString);
 }
 
+void tixiSchemaValidateWithDefaultsFromFile_f(const TixiDocumentHandle *handle,
+                          char *xsdFilename, ReturnCode *error, int lengthString1)
+{
+  char *cString;
+
+  cString = makeCString(xsdFilename, lengthString1);
+  *error = tixiSchemaValidateWithDefaultsFromFile(*handle, cString);
+
+  free(cString);
+}
+
 void tixiSchemaValidateFromString_f(const TixiDocumentHandle *handle,
                           char *xsdString, ReturnCode *error, int lengthString1)
 {

--- a/bindings/fortran/tixi77.h
+++ b/bindings/fortran/tixi77.h
@@ -66,6 +66,7 @@
 #define tixiExportDocumentAsString_f TIXI_EXPORT_DOCUMENT_AS_STRING
 #define tixiImportFromString_f TIXI_IMPORT_FROM_STRING
 #define tixiSchemaValidateFromFile_f TIXI_SCHEMA_VALIDATE_FROM_FILE
+#define tixiSchemaValidateWithDefaultsFromFile_f TIXI_SCHEMA_VALIDATE_WITH_DEFAULTS_FROM_FILE
 #define tixiSchemaValidateFromString_f TIXI_SCHEMA_VALIDATE_FROM_STRING
 #define tixiDTDValidate_f TIXI_DTD_VALIDATE
 #define tixiGetTextElement_f TIXI_GET_TEXT_ELEMENT
@@ -141,6 +142,7 @@
 #define tixiExportDocumentAsString_f FORTRAN_NAME(tixi_export_document_as_string)
 #define tixiImportFromString_f FORTRAN_NAME(tixi_import_from_string)
 #define tixiSchemaValidateFromFile_f FORTRAN_NAME(tixi_schema_validate_from_file)
+#define tixiSchemaValidateWithDefaultsFromFile_f FORTRAN_NAME(tixi_schema_validate_with_defaults_from_file)
 #define tixiSchemaValidateFromString_f FORTRAN_NAME(tixi_schema_validate_from_string)
 #define tixiDTDValidate_f FORTRAN_NAME(tixi_dtd_validata)
 #define tixiGetTextElement_f FORTRAN_NAME(tixi_get_text_element)
@@ -259,6 +261,11 @@ void tixiImportFromString_f(const char* xmlImportString,
                             int lengthString1 );
 
 void tixiSchemaValidateFromFile_f(const TixiDocumentHandle* handle,
+                          char* xsdFilename,
+                          ReturnCode* error,
+                          int lengthString1 );
+
+void tixiSchemaValidateWithDefaultsFromFile_f(const TixiDocumentHandle* handle,
                           char* xsdFilename,
                           ReturnCode* error,
                           int lengthString1 );

--- a/bindings/fortran03/wrappertests.F90
+++ b/bindings/fortran03/wrappertests.F90
@@ -169,6 +169,7 @@ elementFormDefault="qualified" attributeFormDefault="unqualified">&
     VERIFY( size(str) .ge. len(header) )
     VERIFY( str_array_eq(str(1:len(header)),header) )
     VERIFY( SUCCESS .eq. tixiSchemaValidateFromFile(t_handle,valid_schema) )
+    VERIFY( SUCCESS .eq. tixiSchemaValidateWithDefaultsFromFile(t_handle,valid_schema) )
     VERIFY( OPEN_SCHEMA_FAILED .eq. tixiSchemaValidateFromString(t_handle,invalid_schema) )
     VERIFY( NOT_SCHEMA_COMPLIANT .eq. tixiSchemaValidateFromString(t_handle,other_schema) )
     VERIFY( SUCCESS .eq. tixiCloseDocument(t_handle) )

--- a/src/tixi.h
+++ b/src/tixi.h
@@ -766,6 +766,35 @@ DLL_EXPORT ReturnCode tixiImportFromString (const char *xmlImportString, TixiDoc
 DLL_EXPORT ReturnCode tixiSchemaValidateFromFile (const TixiDocumentHandle handle, const char *xsdFilename);
 
 /**
+  @brief Validate XML-document against an XML-schema and insert missing default elements and attributes.
+
+  Validates an XML-document against an XML-schema specified by
+  xsdFilename. This routine should be called after opening a
+  document by ::tixiOpenDocument and before ::tixiSaveDocument if the
+  validation against an XML-schema is desired for the input file and
+  the output file, respectively.
+  If the schema contains default values, these are added to the
+  XML-document (which is not the case for tixiSchemaValidateFromFile).
+
+  <b>Fortran syntax:</b>
+
+  tixi_schema_validate_from_file( integer  handle, character*n xsd_filename, integer error )
+
+  @param[in]  xsdFilename name of the XML-schema-file to be used.
+
+  @param[in]  handle handle to the XML-document.
+
+  @return
+    - SUCCESS              if the document is successfully validated
+    - NOT_WELL_FORMED      if the XML-document is not well formed
+    - NOT_SCHEMA_COMPLIANT if the XML-document is well-formed
+                           but validating against the given XML-schema fails
+    - OPEN_SCHEMA_FAILED   if opening of the XML-schema-file failed
+    - FAILED               for all internal errors
+ */
+DLL_EXPORT ReturnCode tixiSchemaValidateWithDefaultsFromFile (const TixiDocumentHandle handle, const char *xsdFilename);
+
+/**
   @brief Validate XML-document against an XML-schema.
 
   Validates an XML-document against an XML-schema specified by

--- a/src/tixi.h
+++ b/src/tixi.h
@@ -778,7 +778,7 @@ DLL_EXPORT ReturnCode tixiSchemaValidateFromFile (const TixiDocumentHandle handl
 
   <b>Fortran syntax:</b>
 
-  tixi_schema_validate_from_file( integer  handle, character*n xsd_filename, integer error )
+  tixi_schema_validate_with_defaults_from_file( integer  handle, character*n xsd_filename, integer error )
 
   @param[in]  xsdFilename name of the XML-schema-file to be used.
 

--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -795,7 +795,15 @@ DLL_EXPORT ReturnCode tixiSchemaValidateFromFile(const TixiDocumentHandle handle
   xmlDocPtr schema_doc;
 
   schema_doc = xmlReadFile(xsdFilename, NULL, XML_PARSE_NONET);
-  return( validateSchema(handle, &schema_doc));
+  return( validateSchema(handle, &schema_doc, 0));
+}
+
+DLL_EXPORT ReturnCode tixiSchemaValidateWithDefaultsFromFile(const TixiDocumentHandle handle, const char *xsdFilename)
+{
+  xmlDocPtr schema_doc;
+
+  schema_doc = xmlReadFile(xsdFilename, NULL, XML_PARSE_NONET);
+  return( validateSchema(handle, &schema_doc, 1));
 }
 
 DLL_EXPORT ReturnCode tixiSchemaValidateFromString(const TixiDocumentHandle handle, const char *xsdString)
@@ -803,7 +811,7 @@ DLL_EXPORT ReturnCode tixiSchemaValidateFromString(const TixiDocumentHandle hand
   xmlDocPtr schema_doc;
 
   schema_doc = xmlReadMemory(xsdString, (int) strlen(xsdString), NULL, NULL, 0);
-  return(validateSchema(handle, &schema_doc));
+  return(validateSchema(handle, &schema_doc, 0));
 }
 
 

--- a/src/tixiInternal.c
+++ b/src/tixiInternal.c
@@ -1186,7 +1186,7 @@ ReturnCode saveDocument (TixiDocumentHandle handle, const char* xmlFilename, Int
 
 
 
-ReturnCode validateSchema(const TixiDocumentHandle handle, xmlDocPtr* schema_doc)
+ReturnCode validateSchema(const TixiDocumentHandle handle, xmlDocPtr* schema_doc, int withDefaults)
 {
   TixiDocument* document = getDocument(handle);
   xmlSchemaParserCtxtPtr parser_ctxt;
@@ -1219,7 +1219,9 @@ ReturnCode validateSchema(const TixiDocumentHandle handle, xmlDocPtr* schema_doc
     xmlFreeDoc(*schema_doc);
     return FAILED;
   }
-  xmlSchemaSetValidOptions(valid_ctxt, XML_SCHEMA_VAL_VC_I_CREATE); 
+  if (withDefaults) {
+    xmlSchemaSetValidOptions(valid_ctxt, XML_SCHEMA_VAL_VC_I_CREATE);
+  }
   is_valid = (xmlSchemaValidateDoc(valid_ctxt, document->docPtr) == 0);
   xmlSchemaFreeValidCtxt(valid_ctxt);
   xmlSchemaFree(schema);

--- a/src/tixiInternal.c
+++ b/src/tixiInternal.c
@@ -1219,6 +1219,7 @@ ReturnCode validateSchema(const TixiDocumentHandle handle, xmlDocPtr* schema_doc
     xmlFreeDoc(*schema_doc);
     return FAILED;
   }
+  xmlSchemaSetValidOptions(valid_ctxt, XML_SCHEMA_VAL_VC_I_CREATE); 
   is_valid = (xmlSchemaValidateDoc(valid_ctxt, document->docPtr) == 0);
   xmlSchemaFreeValidCtxt(valid_ctxt);
   xmlSchemaFree(schema);

--- a/src/tixiInternal.h
+++ b/src/tixiInternal.h
@@ -332,6 +332,8 @@ ReturnCode saveDocument (TixiDocumentHandle handle, const char* xmlFilename, Int
 
   @param TixiDocument TixiDocumentHandle (in) The TIXIDocument
   @param xmlDocPtr *schema_doc (in) DocPtr with the schema to validate against
+  @param int withDefaults (in) a flag indicating that default elements/attributes in the schema
+                                                            should be added to the tixiDocument
   @return ReturnCode
     - SUCCESS              if the document is successfully validated
     - NOT_WELL_FORMED      if the XML-document is not well formed
@@ -340,7 +342,7 @@ ReturnCode saveDocument (TixiDocumentHandle handle, const char* xmlFilename, Int
     - OPEN_SCHEMA_FAILED   if opening of the XML-schema-file failed
     - FAILED               for all internal errors
  */
-ReturnCode validateSchema(const TixiDocumentHandle handle, xmlDocPtr* schema_doc);
+ReturnCode validateSchema(const TixiDocumentHandle handle, xmlDocPtr* schema_doc, int withDefaults);
 
 
 /**

--- a/tests/TestData/schema_with_defaults.xml
+++ b/tests/TestData/schema_with_defaults.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="schema_with_defaults.xsd">
+    <defaultString/>
+    <elemWithDefaultAttr/>
+</configuration>

--- a/tests/TestData/schema_with_defaults.xsd
+++ b/tests/TestData/schema_with_defaults.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <!-- ROOT ELEMENT -->
+    <xsd:element name="configuration">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="defaultString" type="xsd:string" default="Default string value"/>
+                <xsd:element name="elemWithDefaultAttr">
+                    <xsd:complexType>
+                        <xsd:attribute name="defaultAttr" type="xsd:integer" default="4"/>
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+</xsd:schema>

--- a/tests/validate_schema_with_defaults_check.cpp
+++ b/tests/validate_schema_with_defaults_check.cpp
@@ -1,0 +1,75 @@
+/*
+* Copyright (C) 2015 German Aerospace Center (DLR/SC)
+*
+* Created: 2016-08-23 Melven Roehrig-Zoellner <Melven.Roehrig-Zoellner@DLR.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h" // Brings in the GTest framework
+#include "tixi.h"
+
+
+/**
+  @test Tests for validating (against) schema files with default elements/attributes.
+ */
+
+static TixiDocumentHandle documentHandle = -1;
+
+class ValidateSchemaWithDefaultsTests : public ::testing::Test
+{
+protected:
+  virtual void SetUp()
+  {
+    const char* xmlFilename = "TestData/schema_with_defaults.xml";
+    ASSERT_EQ(SUCCESS, tixiOpenDocument( xmlFilename, &documentHandle ));
+  }
+
+  virtual void TearDown()
+  {
+    ASSERT_EQ(SUCCESS, tixiCloseDocument( documentHandle ));
+  }
+};
+
+TEST_F(ValidateSchemaWithDefaultsTests, tixiValidateSchemaFromFile)
+{
+  const char* schemaFilename = "TestData/schema_with_defaults.xsd";
+  ASSERT_EQ(SUCCESS, tixiSchemaValidateFromFile( documentHandle, schemaFilename ));
+
+  // check that defaults are not there!
+  char *text = NULL;
+  int i;
+  ASSERT_EQ(SUCCESS, tixiGetTextElement( documentHandle, "/configuration/defaultString", &text ));
+  ASSERT_STREQ("", text);
+  ASSERT_EQ(ATTRIBUTE_NOT_FOUND, tixiGetIntegerAttribute( documentHandle, "/configuration/elemWithDefaultAttr", "defaultAttr", &i ));
+}
+
+TEST_F(ValidateSchemaWithDefaultsTests, tixiValidateSchemaWithDefaultsFromFile)
+{
+  const char* schemaFilename = "TestData/schema_with_defaults.xsd";
+  ASSERT_EQ(SUCCESS, tixiSchemaValidateWithDefaultsFromFile( documentHandle, schemaFilename));
+
+  // check that defaults have been inserted
+  char *text = NULL;
+  int i;
+  ASSERT_EQ(SUCCESS, tixiGetTextElement( documentHandle, "/configuration/defaultString", &text));
+  ASSERT_STREQ("Default string value", text);
+  ASSERT_EQ(SUCCESS, tixiGetIntegerAttribute( documentHandle, "/configuration/elemWithDefaultAttr", "defaultAttr", &i ));
+  ASSERT_EQ(4, i);
+}
+
+TEST_F(ValidateSchemaWithDefaultsTests, tixiValidateSchemaWithDefaultsFromFile_notAFile)
+{
+  const char* schemaFilename = "TestData/InvaLid_ScheMa_fIleE_nAmE.xsd";
+  ASSERT_EQ(OPEN_SCHEMA_FAILED, tixiSchemaValidateWithDefaultsFromFile( documentHandle, schemaFilename ));
+}


### PR DESCRIPTION
In the XML Schema file you can define default values for attributes and elements.
This fix adds these default values to the XML tree when validating.