### PR TITLE
Don't check for duplicate UIDs in tixiUIDCheckExists

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -2809,9 +2809,16 @@ DLL_EXPORT ReturnCode tixiUIDCheckExists(TixiDocumentHandle handle, const char *
   TixiDocument *document = getDocument(handle);
   ReturnCode error = FAILED;
 
-  error = tixiUIDCheckDuplicates(handle);
-  if (error != SUCCESS) {
-    return error;
+  if(!document)
+    return INVALID_HANDLE;
+
+  // if the UID list is already set, delete and rebuild it.
+  if(document->uidListHead) {
+    uid_clearUIDList(document);
+  }
+
+  if (uid_readDocumentUIDs(document) != SUCCESS) {
+    return FAILED;
   }
 
   if (uid_checkExists(document, uID) == 0) {

--- a/tests/uid_check.cpp
+++ b/tests/uid_check.cpp
@@ -55,6 +55,11 @@ TEST(uid_checks, tixiUIDCheck_duplicates)
   ASSERT_TRUE( tixiUIDCheckDuplicates( documentHandle ) == UID_NOT_UNIQUE);
   ASSERT_TRUE( tixiCloseDocument( documentHandle ) == SUCCESS );
 
+  /* check if tixiUIDCheckExists returns true on duplicate UID */
+  ASSERT_TRUE( tixiOpenDocument( filename_uid_duplicated, &documentHandle ) == SUCCESS );
+  ASSERT_TRUE( tixiUIDCheckExists( documentHandle, "a" ) == SUCCESS);
+  ASSERT_TRUE( tixiCloseDocument( documentHandle ) == SUCCESS );
+
   /* check a document without uids */
   ASSERT_TRUE( tixiOpenDocument( filename_without_uids, &documentHandle ) == SUCCESS );
   ASSERT_TRUE( tixiUIDCheckDuplicates( documentHandle ) == SUCCESS);


### PR DESCRIPTION
This commit removes the call to tixiUIDCheckDuplicates from tixiUIDCheckExists, because it is illogical here. Rebuilding the headlist of the document has been added instead (Previously called by tixiUIDCheckDuplicates).

Adresses issue #83