### PR TITLE
Added travis ci for linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+compiler:
+  - gcc
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y --force-yes cmake libxml2-dev libxslt-dev libcurl4-openssl-dev python doxygen gfortran
+  
+before_script:
+  - mkdir build
+  - cd build
+
+script: 
+  - cmake -DTIXI_BUILD_TESTS=ON ..
+  - make
+  - cd tests
+  - ./TIXI-unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,6 @@ script:
   - cmake -DTIXI_BUILD_TESTS=ON ..
   - make
   - cd tests
-  - ./TIXI-unittests
+  # Don't run the curl tests, as curl seems to be defect on Ubuntu 12.04.
+  # This can be even tested with /usr/bin/curl file:///path/to/file
+  - ./TIXI-unittests --gtest_filter=-*curlGet*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ compiler:
   - gcc
 
 before_install:
+  - curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/Release.key | sudo apt-key add -
+  - echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/ /" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes cmake-data gfortran
+  - sudo apt-get install -y --force-yes cmake cmake-data gfortran
   
 before_script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes cmake libxml2-dev libxslt-dev libcurl4-openssl-dev python doxygen gfortran
+  - sudo apt-get install -y --force-yes cmake-data gfortran
   
 before_script:
   - mkdir build

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+Build-Status: [![Build Status](https://travis-ci.org/DLR-SC/tixi.svg?branch=master)](https://travis-ci.org/DLR-SC/tixi)
+
 # TIXI #
 
  - Binary Downloads:  https://github.com/DLR-SC/tixi/wiki/Downloads

--- a/tests/TestData/minimal.xml
+++ b/tests/TestData/minimal.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root/>

--- a/tests/utils_check.cpp
+++ b/tests/utils_check.cpp
@@ -244,7 +244,7 @@ TEST_F(UtilsTest, localPathToURI)
 TEST_F(UtilsTest, loadFileToString)
 {
   const char* expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<root/>\n";
-  char* string = loadFileToString("TestData/out.xml");
+  char* string = loadFileToString("TestData/minimal.xml");
   ASSERT_STREQ(expected, string);
   free(string);
 }


### PR DESCRIPTION
I had to disable two curl related tests, as curl on Ubuntu 12.04 seems to be not able to load local files.

This also makes the local file related curl tests fail.