### PR TITLE
Missing return parameter in definition of tixiUIDCheckExists.m

### DIFF
--- a/bindings/matlab/tixiUIDCheckExists.m
+++ b/bindings/matlab/tixiUIDCheckExists.m
@@ -1,4 +1,4 @@
-function tixiUIDCheckExists(handle, uID)
+function found = tixiUIDCheckExists(handle, uID)
     if (ischar(handle))
         error('Invalid type of argument "handle"');
     end


### PR DESCRIPTION
This commit modifies the hand-written tixiUIDCheckExists.m so that it now has a return parameter

fixes #84