### PR TITLE
Remove  C++ style comments from common.h and tiximatlab.c

### DIFF
--- a/bindings/bindings_generator/matlab_generator.py
+++ b/bindings/bindings_generator/matlab_generator.py
@@ -402,7 +402,7 @@ extern "C" {
             call += '}\n'
         
         call += '''else {
-    // this is only executed if the function could not be identified
+    /* this is only executed if the function could not be identified */
     char text[255];
 '''
         call += '    snprintf(text, 250, "%%s is not a valid %s function!\\n", functionName);\n' % self.prefix

--- a/bindings/matlab/common.h
+++ b/bindings/matlab/common.h
@@ -35,7 +35,7 @@
 #include "mex.h"
 
 #ifndef __PACKAGENAME__
-// define a generic package name if macro is not defined in including source file
+/* define a generic package name if macro is not defined in including source file */
 #define __PACKAGENAME__ "TIXI"
 #endif
 


### PR DESCRIPTION
This commit makes sure that tiximatlab.c and common.h are free of C++ style comments, so that gcc does not return with "C++ style commens are not allowed in ISO C90"

fixes #80