### PR TITLE
Fix unexpected default return value of tixiGetDoubleElement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ compiler:
   - gcc
 
 before_install:
-  - curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/Release.key | sudo apt-key add -
-  - echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/ /" | sudo tee -a /etc/apt/sources.list
+  - curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_16.04/Release.key | sudo apt-key add -
+  - echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_16.04/ /" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   - sudo apt-get install -y --force-yes cmake cmake-data gfortran
   
@@ -16,6 +16,4 @@ script:
   - cmake -DBUILD_SHARED_LIBS=ON -DTIXI_BUILD_TESTS=ON ..
   - make
   - cd tests
-  # Don't run the curl tests, as curl seems to be defect on Ubuntu 12.04.
-  # This can be even tested with /usr/bin/curl file:///path/to/file
-  - ./TIXI-unittests --gtest_filter=-*curlGet*
+  - ./TIXI-unittests

--- a/src/tixi.h
+++ b/src/tixi.h
@@ -878,9 +878,8 @@ DLL_EXPORT ReturnCode tixiDTDValidate (const TixiDocumentHandle handle, const ch
   @brief Retrieve text content of an element.
 
   Returns the text content of the element specified by elementPath in the
-  document specified by handle. elementPath must refer to exactly one
-  element which has only a text node and zero or more attributes but
-  no further children with text nodes. If an error occurs text is set
+  document specified by handle. If elementPath does not refer to an element with
+  textual content, an empty string is returned. If an error occurs text is set
   to NULL. On successful return the memory used for text is allocated
   internally and must not be released by the user. The deallocation
   is handle when the document referred to by handle is closed.
@@ -911,9 +910,7 @@ DLL_EXPORT ReturnCode tixiGetTextElement (const TixiDocumentHandle handle,
   @brief Retrieve integer content of an element.
 
   Returns the content of the element specified by elementPath in the
-  document specified by handle as an integer. elementPath must refer to exactly one
-  element which has only a text node and zero or more attributes but
-  no further children with text nodes. If an error occurs text is set
+  document specified by handle as an integer. If an error occurs text is set
   to NULL. On successful return the memory used for text is allocated
   internally and must not be released by the user. The deallocation
   is handle when the document referred to by handle is closed.
@@ -935,6 +932,7 @@ DLL_EXPORT ReturnCode tixiGetTextElement (const TixiDocumentHandle handle,
     - INVALID_XPATH if elementPath is not a well-formed XPath-expression
     - ELEMENT_NOT_FOUND if elementPath does not point to a node in the XML-document
     - ELEMENT_PATH_NOT_UNIQUE if elementPath resolves not to a single element but to a list of elements
+    - NO_NUMBER if the content of elementPath cannot be interpreted as a numeric value
  */
 DLL_EXPORT ReturnCode tixiGetIntegerElement (const TixiDocumentHandle handle, const char *elementPath, int *number);
 
@@ -943,9 +941,7 @@ DLL_EXPORT ReturnCode tixiGetIntegerElement (const TixiDocumentHandle handle, co
 
   Returns the content of the element specified by elementPath in the
   document specified by handle as a floating point
-  number. elementPath must refer to exactly one element which has
-  only a text node and zero or more attributes but no further
-  children with text nodes. If an error occurs number is set to
+  number. If an error occurs number is set to
   NULL.
 
   <b>Fortran syntax:</b>
@@ -965,6 +961,7 @@ DLL_EXPORT ReturnCode tixiGetIntegerElement (const TixiDocumentHandle handle, co
     - INVALID_XPATH if elementPath is not a well-formed XPath-expression
     - ELEMENT_NOT_FOUND if elementPath does not point to a node in the XML-document
     - ELEMENT_PATH_NOT_UNIQUE if elementPath resolves not to a single element but to a list of elements
+    - NO_NUMBER if the content of elementPath cannot be interpreted as a numeric value
  */
 DLL_EXPORT ReturnCode tixiGetDoubleElement (const TixiDocumentHandle handle, const char *elementPath, double *number);
 

--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -880,9 +880,13 @@ DLL_EXPORT ReturnCode tixiGetIntegerElement(const TixiDocumentHandle handle, con
     return error;
   }
 
-  *number = atoi(text);
-
-  return SUCCESS;
+  if (isNumeric(text)) {
+    *number = atoi(text);
+    return SUCCESS;
+  }
+  else {
+      return NO_NUMBER;
+  }
 }
 
 DLL_EXPORT ReturnCode tixiGetDoubleElement(const TixiDocumentHandle handle, const char *elementPath, double *number)
@@ -897,10 +901,13 @@ DLL_EXPORT ReturnCode tixiGetDoubleElement(const TixiDocumentHandle handle, cons
     return error;
   }
 
-  *number = atof(text);
-  return SUCCESS;
-
-  /* use   strtod(nptr, (char **)NULL); to check for errors */
+  if (isNumeric(text)) {
+    *number = atof(text);
+    return SUCCESS;
+  }
+  else {
+      return NO_NUMBER;
+  }
 }
 
 

--- a/src/tixiUtils.c
+++ b/src/tixiUtils.c
@@ -406,3 +406,15 @@ char *substring(const char *str, int start_pos, int end_pos)
 
   return substr;
 }
+
+int isNumeric (const char * s)
+{
+    char * p;
+
+    if (s == NULL || *s == '\0') {
+      return 0;
+    }
+
+    strtod (s, &p);
+    return *p == '\0';
+}

--- a/src/tixiUtils.h
+++ b/src/tixiUtils.h
@@ -173,6 +173,12 @@ TIXI_INTERNAL_EXPORT char* loadFileToString(const char* path);
  */
 TIXI_INTERNAL_EXPORT char* stringToLower(char* string);
 
+/**
+  @brief tests, wether a given string is numeric
+  @return
+    1, if the string can be converted to a number and 0 else.
+ */
+TIXI_INTERNAL_EXPORT int isNumeric (const char * s);
 
 /**
   @brief Strips the first len bytes of the string.

--- a/tests/get_element_check.cpp
+++ b/tests/get_element_check.cpp
@@ -116,6 +116,14 @@ TEST_F(GetElementTests, getDoubleElement)
   ASSERT_TRUE( number == 30.0);
 }
 
+TEST_F(GetElementTests, getDoubleElement_fail)
+{
+  double number = 0.;
+  const char* elementPath = "/plane/wings/wing[1]/centerOfGravity";
+
+  ASSERT_TRUE( tixiGetDoubleElement( documentHandle, elementPath, &number ) == NO_NUMBER );
+}
+
 TEST_F(GetElementTests, getIntegerElement)
 {
   int number = 0;

--- a/tests/webmethods_check.cpp
+++ b/tests/webmethods_check.cpp
@@ -21,12 +21,7 @@
 
 TEST(WebMethods, curlGetFileToLocalDisk)
 {
-  // create some local dummy file
-  FILE* f = fopen("mytmpfile.sh", "w");
-  fprintf(f, "hello world\n");
-  fclose(f);
-
-  int res = curlGetFileToLocalDisk("file://mytmpfile.sh", "tmp.sh");
+  int res = curlGetFileToLocalDisk("https://raw.githubusercontent.com/DLR-SC/tixi/master/tests/TestData/textfile.txt", "tmp.sh");
   ASSERT_EQ(0, res);
   remove ("tmp.sh");
   remove ("mytmpfile.sh");
@@ -41,15 +36,8 @@ TEST(WebMethods, curlGetFileToLocalDisk_invalidPath)
 
 TEST(WebMethods, curlGetURLInMemory)
 {
-  // create some local dummy file
-  FILE* f = fopen("mytmpfile.sh", "w");
-  fprintf(f, "hello world");
-  fclose(f);
-
-  char* text = curlGetURLInMemory("file://mytmpfile.sh");
-  ASSERT_STREQ("hello world", text);
-
-  remove ("mytmpfile.sh");
+  char* text = curlGetURLInMemory("https://raw.githubusercontent.com/DLR-SC/tixi/master/tests/TestData/textfile.txt");
+  ASSERT_STREQ("This is just some textfile\n", text);
   free(text);
 }
 


### PR DESCRIPTION
 - This fixes #129 
 - Fix documentation of `tixiGetTextElement`, `tixiGetDoubleElement` and `tixiGetIntegerElement`: TiXI can handle elements with both text content and additional child elements.
 - Small API change: `tixiGetDoubleElement` and `tixiGetIntegerElement` return `NO_NUMBER`, if they are called for elements for which the context cannot be interpreted numerically. Previously, they returned 0.0, resp. 0.
 - `tixiGetTextElement` still returns an empty string if the xpath points to an element without textual content.
 - Update Travis Build System to Ubuntu 16.04