### PR TITLE
Add -fPIC compile flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ set(TIXI_HDR tixi.h tixiData.h tixiInternal.h tixiUtils.h)
 
 
 if(CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fmessage-length=0")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wall -fmessage-length=0")
 endif()
 
 set(TIXI_LIBS curllib LibXslt::LibXslt LibXml2::LibXml2)


### PR DESCRIPTION
When building tigl with tixi built from source, ld gave me some linking errors.
It suggested that libtixi3.a should be compiled using the '-fPIC' flag, so this PR adds this.
Now the linking succeeds.