### PR TITLE
allow adding empty float vectors

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -1516,10 +1516,6 @@ DLL_EXPORT ReturnCode tixiAddFloatVector (const TixiDocumentHandle handle, const
   int i;
   int stringSize = 0;
 
-  if(numElements < 1) {
-    return FAILED;
-  }
-
   if (!format) {
     format = "%g";
   };
@@ -1536,14 +1532,17 @@ DLL_EXPORT ReturnCode tixiAddFloatVector (const TixiDocumentHandle handle, const
 
   /* copy strings to stringVector */
   stringVector[0] = '\0';
-  textBuffer = buildString(format, vector[0]);
-  strcat(stringVector, textBuffer);
-  free(textBuffer);
-  for(i=1; i<numElements; i++) {
-    textBuffer = buildString(format, vector[i]);
-    strcat(stringVector, VECTOR_SEPARATOR);
-    strcat(stringVector, textBuffer);
-    free(textBuffer);
+
+  if (numElements>0) {
+      textBuffer = buildString(format, vector[0]);
+      strcat(stringVector, textBuffer);
+      free(textBuffer);
+      for(i=1; i<numElements; i++) {
+        textBuffer = buildString(format, vector[i]);
+        strcat(stringVector, VECTOR_SEPARATOR);
+        strcat(stringVector, textBuffer);
+        free(textBuffer);
+      }
   }
 
   /* Add element */

--- a/tests/vector_check.cpp
+++ b/tests/vector_check.cpp
@@ -84,6 +84,17 @@ TEST_F(VectorTests, tixiVectorAddTests)
   ASSERT_TRUE ( tixiCloseDocument( tmpHandle ) == SUCCESS );
 }
 
+TEST_F(VectorTests, tixiVectorAddNullTests)
+{
+  int count = 0;
+  double* points = NULL;
+  const char* xmlOutName = "x.xml";
+
+  // write parts of the array to an intermediate file
+  ASSERT_TRUE ( tixiAddFloatVector(documentHandleAdd, "/a", "test", points, count, "%g") == SUCCESS );
+  ASSERT_TRUE ( tixiSaveDocument(documentHandleAdd, xmlOutName) == SUCCESS );
+}
+
 TEST_F(VectorTests, tixiUpdateVectorTests)
 {
   int count = 0;


### PR DESCRIPTION
I see no reason, why adding float vectors with zero elements should not be allowed. 

This PR fixes #137.