### PR TITLE
Deprecate all array functions.

### DIFF
--- a/bindings/bindings_generator/cheader_parser.py
+++ b/bindings/bindings_generator/cheader_parser.py
@@ -83,8 +83,11 @@ class CHeaderFileParser(object):
         '''
         Parse methods and their annotations
         '''
-        dec_pattern = re.compile(self.decoration + 
-            r'\s+(?P<fundec>.*?\([\w\s,*]*(\);)?)')
+
+        # search also for DEPRECATED( ... ) declarations
+        dec_pattern = re.compile(r'(?:DEPRECATED\(\s*)?'
+            + self.decoration
+            + r'\s+(?P<fundec>.*?\([\w\s,*]*(\);)?)')
             
         anno_pattern = re.compile('#annotate.*?#')
         
@@ -104,11 +107,15 @@ class CHeaderFileParser(object):
                     if not endterm in line:
                         continuing = True
                     else:
+                        if "DEPRECATED" in fundec:
+                            fundec = fundec.split(', "DEPRECATED:')[0]
                         fundec_dict.append({'line': index, 'declaration': fundec})
             else:
                 fundec += ' ' + line.strip()
                 if endterm in line:
                     continuing = False
+                    if "DEPRECATED" in fundec:
+                        fundec = fundec.split(', "DEPRECATED:')[0]
                     fundec_dict.append({'line': index, 'declaration': fundec})
         
         for index, line in enumerate(self.lines):

--- a/src/tixi.h
+++ b/src/tixi.h
@@ -29,6 +29,16 @@ extern "C" {
 #define DLL_EXPORT
 #endif
 
+// DEPRECATION MACRO. THE deprecation message must start with "DEPRECATED: ...",
+// otherwise the bindings generator will not work.
+#ifdef __GNUC__
+#define DEPRECATED(X, MSG) X __attribute__((deprecated(MSG)))
+#elif defined(_MSC_VER)
+#define DEPRECATED(X, MSG) __declspec(deprecated(MSG)) X
+#else
+#define DEPRECATED(X, MSG) X
+#endif
+
 /* \mainpage TIXI Manual
 <b>Contents:</b>
   - \link Glossary Glossary\endlink
@@ -2775,6 +2785,8 @@ DLL_EXPORT ReturnCode tixiGetFloatVector (const TixiDocumentHandle handle, const
 /**
   @brief Retrieves the number of dimensions of an Array.
 
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
+
   Returns the number of separate dimensions defined in sub-tags of the array in CPACS.
   For each dimension there is a finite set of allowed values that can be retrieved by
   "tixiGetArrayValues".
@@ -2818,12 +2830,15 @@ DLL_EXPORT ReturnCode tixiGetFloatVector (const TixiDocumentHandle handle, const
     - ELEMENT_PATH_NOT_UNIQUE if arrayPath resolves not to a single element but to a list of elements
     - ELEMENT_NOT_FOUND if the rrayPath points to a element that is no array
  */
-DLL_EXPORT ReturnCode tixiGetArrayDimensions (const TixiDocumentHandle handle,
-                                              const char *arrayPath, int *dimensions);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayDimensions (const TixiDocumentHandle handle,
+                                                         const char *arrayPath, int *dimensions),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Retrieves the sizes of all dimensions of the array definition, and the overall array size (product of all dimensions's sizes).
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check tixiGetArrayDimensions()
 
@@ -2849,12 +2864,15 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensions (const TixiDocumentHandle handle,
   #annotate out: 2AM# sizes is an output array that has to be manually preallocated
   @endcond
  */
-DLL_EXPORT ReturnCode tixiGetArrayDimensionSizes (const TixiDocumentHandle handle, const char *arrayPath,
-                                                  int *sizes, int *linearArraySize);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayDimensionSizes (const TixiDocumentHandle handle, const char *arrayPath,
+                                                             int *sizes, int *linearArraySize),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Retrieves the names of all dimensions.
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check tixiGetArrayDimensions()
 
@@ -2879,11 +2897,14 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionSizes (const TixiDocumentHandle handl
   #annotate out: 2AM# one user specified return array (of strings)
   @endcond
  */
-DLL_EXPORT ReturnCode tixiGetArrayDimensionNames (const TixiDocumentHandle handle,
-                                                  const char *arrayPath, char **dimensionNames);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayDimensionNames (const TixiDocumentHandle handle,
+                                                             const char *arrayPath, char **dimensionNames),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 /**
   @brief Retrieves the selected dimension's values (e.g. separate allowed angles etc.).
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check tixiGetArrayDimensions()
 
@@ -2908,12 +2929,15 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionNames (const TixiDocumentHandle handl
   #annotate out: 3AM# the size of the array "dimensionValues" is determined by a prior call to tixiGetArrayDimensionSizes
   @endcond
  */
-DLL_EXPORT ReturnCode tixiGetArrayDimensionValues (const TixiDocumentHandle handle, const char *arrayPath,
-                                                   const int dimension, double *dimensionValues);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayDimensionValues (const TixiDocumentHandle handle, const char *arrayPath,
+                                                              const int dimension, double *dimensionValues),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Retrieves the number of parameters of an array.
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check tixiGetArrayDimensions()
 
@@ -2937,11 +2961,16 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionValues (const TixiDocumentHandle hand
     - ELEMENT_PATH_NOT_UNIQUE if arrayPath resolves not to a single element but to a list of elements
     - ELEMENT_NOT_FOUND if arrayPath points to a element that is no array
  */
-DLL_EXPORT ReturnCode tixiGetArrayParameters (const TixiDocumentHandle handle, const char *arrayPath, int *parameters);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayParameters (const TixiDocumentHandle handle,
+                                                         const char *arrayPath,
+                                                         int *parameters),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Retrieves names of all parameters
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check tixiGetArrayDimensions()
 
@@ -2965,12 +2994,15 @@ DLL_EXPORT ReturnCode tixiGetArrayParameters (const TixiDocumentHandle handle, c
   #annotate out: 2AM# one user specified return array (of strings)
   @endcond
  */
-DLL_EXPORT ReturnCode tixiGetArrayParameterNames (const TixiDocumentHandle handle,
-                                                  const char *arrayPath, char **parameterNames);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayParameterNames (const TixiDocumentHandle handle,
+                                                             const char *arrayPath, char **parameterNames),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Reads in an array. The memory management of the array is done by tixi.
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check ::tixiGetArrayDimensions()
 
@@ -3001,12 +3033,15 @@ DLL_EXPORT ReturnCode tixiGetArrayParameterNames (const TixiDocumentHandle handl
   #annotate out: 4A(3) # the size of the array "values" is determined by arraySize
   @endcond
  */
-DLL_EXPORT ReturnCode tixiGetArray (const TixiDocumentHandle handle, const char *arrayPath,
-                                    const char *elementName, int arraySize, double **values);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArray (const TixiDocumentHandle handle, const char *arrayPath,
+                                               const char *elementName, int arraySize, double **values),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Getter function to take one multidimensionally specified element from a complete array, retrieved earlier.
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   For an array use example, please check tixiGetArrayDimensions()
 
@@ -3021,11 +3056,17 @@ DLL_EXPORT ReturnCode tixiGetArray (const TixiDocumentHandle handle, const char 
 
   @return The element fetched
 */
-DLL_EXPORT double tixiGetArrayValue(const double *array, const int *dimSize, const int *dimPos, const int dims);
+DEPRECATED(DLL_EXPORT double tixiGetArrayValue(const double *array,
+                                               const int *dimSize,
+                                               const int *dimPos,
+                                               const int dims),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Helper function.
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   Returns the number of sub elements in CPACS arrays (either vector or array type).
 
@@ -3049,12 +3090,15 @@ DLL_EXPORT double tixiGetArrayValue(const double *array, const int *dimSize, con
     - ELEMENT_PATH_NOT_UNIQUE if arrayPath resolves not to a single element but to a list of elements
     - ELEMENT_NOT_FOUND if arrayPath points to a element that is no array
  */
-DLL_EXPORT ReturnCode tixiGetArrayElementCount (const TixiDocumentHandle handle, const char *arrayPath,
-                                                const char *elementName, int *elements);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayElementCount (const TixiDocumentHandle handle, const char *arrayPath,
+                                                           const char *elementName, int *elements),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**
   @brief Helper function.
+
+  <b>DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3.</b>
 
   Returns the tag names of sub elements of mapType given.
 
@@ -3078,8 +3122,9 @@ DLL_EXPORT ReturnCode tixiGetArrayElementCount (const TixiDocumentHandle handle,
     - ELEMENT_PATH_NOT_UNIQUE if arrayPath resolves not to a single element but to a list of elements
     - ELEMENT_NOT_FOUND if arrayPath points to a element that is no array
  */
-DLL_EXPORT ReturnCode tixiGetArrayElementNames (const TixiDocumentHandle handle, const char *arrayPath,
-                                                const char *elementType, char **elementNames);
+DEPRECATED(DLL_EXPORT ReturnCode tixiGetArrayElementNames (const TixiDocumentHandle handle, const char *arrayPath,
+                                                           const char *elementType, char **elementNames),
+"DEPRECATED: This is a CPACS specific function, that is no longer needed in CPACS versions >= 3");
 
 
 /**

--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -2185,6 +2185,7 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensions (const TixiDocumentHandle handle,
                                               const char *arrayPath, int *dimensions)
 {
 
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayDimensions is an outdated CPACS specific function. It will be removed in the next major release");
   return tixiGetArrayElementCount(handle, arrayPath, "vector", dimensions);
 }
 
@@ -2193,7 +2194,7 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionNames (const TixiDocumentHandle handl
                                                   const char *arrayPath,
                                                   char **dimensionNames)
 {
-
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayDimensionNames is an outdated CPACS specific function. It will be removed in the next major release");
   return tixiGetArrayElementNames(handle, arrayPath, "vector", dimensionNames);
 }
 
@@ -2214,7 +2215,7 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionSizes (const TixiDocumentHandle handl
   int dim = 0;
 
 
-
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayDimensionSizes is an outdated CPACS specific function. It will be removed in the next major release");
   if (!document) {
     printMsg(MESSAGETYPE_ERROR, "Error: Invalid document handle.\n");
     free(xpathSubElementsName);
@@ -2299,7 +2300,7 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionValues (const TixiDocumentHandle hand
   int count = 0;
 
 
-
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayDimensionValues is an outdated CPACS specific function. It will be removed in the next major release");
   if (!document) {
     printMsg(MESSAGETYPE_ERROR, "Error: Invalid document handle.\n");
     free(xpathSubElementsName);
@@ -2370,7 +2371,7 @@ DLL_EXPORT ReturnCode tixiGetArrayDimensionValues (const TixiDocumentHandle hand
 DLL_EXPORT ReturnCode tixiGetArrayParameters (const TixiDocumentHandle handle,
                                               const char *arrayPath, int *parameters)
 {
-
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayParameters is an outdated CPACS specific function. It will be removed in the next major release");
   return tixiGetArrayElementCount(handle, arrayPath, "array", parameters);
 }
 
@@ -2379,7 +2380,7 @@ DLL_EXPORT ReturnCode tixiGetArrayParameterNames (const TixiDocumentHandle handl
                                                   const char *arrayPath,
                                                   char **parameterNames)
 {
-
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayParameterNames is an outdated CPACS specific function. It will be removed in the next major release");
   return tixiGetArrayElementNames(handle, arrayPath, "array", parameterNames);
 }
 
@@ -2399,7 +2400,7 @@ DLL_EXPORT ReturnCode tixiGetArray (const TixiDocumentHandle handle, const char 
   double * tmpArray = NULL;
   int count = 0;
 
-
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArray is an outdated CPACS specific function. It will be removed in the next major release");
   if (!document) {
     printMsg(MESSAGETYPE_ERROR, "Error: Invalid document handle.\n");
     free(xpathSubElementsName);
@@ -2514,6 +2515,8 @@ DLL_EXPORT double tixiGetArrayValue(const double *array, const int *dimSize, con
   int i = 0;
   int index = 0;
 
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayValue is an outdated CPACS specific function. It will be removed in the next major release");
+
   assert(dims > 0);
 
   /*
@@ -2539,6 +2542,8 @@ DLL_EXPORT ReturnCode tixiGetArrayElementCount (const TixiDocumentHandle handle,
   xmlNodeSetPtr nodes = NULL;
   char *infix = "/*[@mapType=\"";
   char *xpathSubElementsName = NULL;
+
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayElementCount is an outdated CPACS specific function. It will be removed in the next major release");
 
   if (!document || !document->docPtr) {
     printMsg(MESSAGETYPE_ERROR, "Error: Invalid document handle.\n");
@@ -2588,6 +2593,8 @@ DLL_EXPORT ReturnCode tixiGetArrayElementNames (const TixiDocumentHandle handle,
   char *infix = "/*[@mapType=\"";    /* find all arrays in subelements of the given path */
   int elements,elem = 0;
   char *xpathSubElementsName = NULL;
+
+  printMsg(MESSAGETYPE_WARNING, "DEPRECATED: tixiGetArrayElementNames is an outdated CPACS specific function. It will be removed in the next major release");
 
   if (!document) {
     printMsg(MESSAGETYPE_ERROR, "Error: Invalid document handle.\n");


### PR DESCRIPTION
This PR fixes #142.

@MarAlder, @CLiersch, would this be a feasible solution, at least until the next major release?

@rainman110, The deprecation macro is a bit hacky and interferes with the bindings generator quite a bit, but I just realized today that there is no portable way for declaring methods as deprecated in pure C and this is the best solution that I could think of. If you know of any cleaner solutions...?