### PR TITLE
Ignore the mapType attribute for tixiGetFloatVector and tixiGetVectorSize

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -2140,16 +2140,6 @@ DLL_EXPORT ReturnCode tixiGetVectorSize (const TixiDocumentHandle handle, const 
   char *token = NULL;
   *nElements = 0;
 
-  error = tixiGetTextAttribute(handle, vectorPath, MAPTYPE_IDENTIFIER, &tmpString);
-  if (error != SUCCESS) {
-    return error;
-  } else {
-    tmpString = stringToLower(tmpString);   /* side effect: changes original string anyway */
-    if ((strcmp(tmpString, VECTOR_ATTRIBUTE_NAME))) {   /* if not of type "vector": */
-      return ELEMENT_NOT_FOUND;
-    }
-  }
-
   error = tixiGetTextElement(handle, vectorPath, &tmpString);
   if(error != SUCCESS) {
     return error;
@@ -2642,17 +2632,6 @@ DLL_EXPORT ReturnCode tixiGetFloatVector (const TixiDocumentHandle handle, const
   int count = 0;
   char *token = NULL;
   TixiDocument *document = NULL;
-
-
-  error = tixiGetTextAttribute(handle, vectorPath, MAPTYPE_IDENTIFIER, &tmpString);
-  if (error != SUCCESS) {
-    return error;
-  } else {
-    tmpString = stringToLower(tmpString);
-    if ((strcmp(tmpString, VECTOR_ATTRIBUTE_NAME))) {
-      return ELEMENT_NOT_FOUND;
-    }
-  }
 
   error = tixiGetTextElement(handle, vectorPath, &tmpString); /* check if element is of right type */
   if (error != SUCCESS) {

--- a/tests/vector_check.cpp
+++ b/tests/vector_check.cpp
@@ -54,7 +54,7 @@ TEST_F(VectorTests, tixiVectorGetTests)
   // check sizes
   ASSERT_TRUE ( tixiGetVectorSize(documentHandleGet, "/a/aeroPerformanceMap/cfx", &count) == SUCCESS );
   ASSERT_TRUE ( count == 32 );
-  ASSERT_TRUE ( tixiGetVectorSize(documentHandleGet, "/a/aeroPerformanceMap/cfy", &count) == ELEMENT_NOT_FOUND );
+  ASSERT_TRUE ( tixiGetVectorSize(documentHandleGet, "/a/aeroPerformanceMap/cfy", &count) == SUCCESS );
   ASSERT_TRUE ( tixiGetVectorSize(documentHandleGet, "/a/aeroPerformanceMap/cfz", &count) == SUCCESS );
   ASSERT_TRUE ( count == 2 );
 


### PR DESCRIPTION
There is no reason to be pendantic about the mapType. Without it, the function can be used to read arrays from CPACS node with a different baseType.

fixes #143