### PR TITLE
Fixed text retreiving with special characters

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -836,6 +836,7 @@ DLL_EXPORT ReturnCode tixiGetTextElement(const TixiDocumentHandle handle, const 
   TixiDocument *document = getDocument(handle);
   xmlNodePtr element = NULL;
   ReturnCode error = SUCCESS;
+  int nChilds = 0;
 
   if (!document) {
     printMsg(MESSAGETYPE_ERROR, "Error: Invalid document handle.\n");
@@ -845,10 +846,14 @@ DLL_EXPORT ReturnCode tixiGetTextElement(const TixiDocumentHandle handle, const 
   error = checkElement(document->xpathContext, elementPath, &element);
 
   if (!error) {
-    char *textPtr = NULL;
+    xmlChar *textPtr = NULL;
 
-    if (!xmlNodeIsText(element)) {
+    nChilds = getChildNodeCount(element);
+    if (!xmlNodeIsText(element) && nChilds > 1) {
         textPtr = (char *) xmlNodeListGetString(document->docPtr, element->children, 0);
+    }
+    else if(!xmlNodeIsText(element) && nChilds == 1 && xmlNodeIsText(element->children)) {
+        textPtr = (char *) xmlNodeGetContent(element->children);
     }
     else {
         textPtr = (char *) xmlNodeGetContent(element);

--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -849,14 +849,15 @@ DLL_EXPORT ReturnCode tixiGetTextElement(const TixiDocumentHandle handle, const 
     xmlChar *textPtr = NULL;
 
     nChilds = getChildNodeCount(element);
-    if (!xmlNodeIsText(element) && nChilds > 1) {
-        textPtr = (char *) xmlNodeListGetString(document->docPtr, element->children, 0);
+
+    if (xmlNodeIsText(element)) {
+        textPtr = (char *) xmlNodeGetContent(element);
     }
-    else if(!xmlNodeIsText(element) && nChilds == 1 && xmlNodeIsText(element->children)) {
+    else if(nChilds == 1 && xmlNodeIsText(element->children)) {
         textPtr = (char *) xmlNodeGetContent(element->children);
     }
     else {
-        textPtr = (char *) xmlNodeGetContent(element);
+        textPtr = (char *) xmlNodeListGetString(document->docPtr, element->children, 0);
     }
 
     if ( textPtr ) {

--- a/src/tixiInternal.c
+++ b/src/tixiInternal.c
@@ -1275,3 +1275,11 @@ int isParent(xmlNodePtr possibleParent, xmlNodePtr n)
     
     return 0;
 }
+
+int getChildNodeCount(const xmlNodePtr nodePtr)
+{
+    int i = 0;
+    for (xmlNodePtr node = nodePtr->children; node; node = node->next, i++);
+    return i--;
+}
+

--- a/src/tixiInternal.h
+++ b/src/tixiInternal.h
@@ -390,6 +390,13 @@ TIXI_INTERNAL_EXPORT ReturnCode reorderXmlElements(TixiDocumentHandle handle, co
  */
 int isParent(xmlNodePtr p, xmlNodePtr n);
 
+/**
+ * @brief Returns the number of child nodes of an element
+ * @return Child node count
+ */
+TIXI_INTERNAL_EXPORT int getChildNodeCount(const xmlNodePtr nodePtr);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/TestData/textelements.xml
+++ b/tests/TestData/textelements.xml
@@ -1,4 +1,5 @@
 <root>
     <a>Text</a>
     <b>Text1<c>Text2</c>Text3</b>
+    <d><e>Text4</e></d>
 </root>

--- a/tests/internal_check.cpp
+++ b/tests/internal_check.cpp
@@ -29,7 +29,7 @@ TEST(InternalCheck, getChildNodeCount)
 
     xmlNodePtr element = NULL;
     ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root", &element));
-    EXPECT_EQ(2, getChildNodeCount(element));
+    EXPECT_EQ(3, getChildNodeCount(element));
 
     ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root/a", &element));
     EXPECT_EQ(1, getChildNodeCount(element));

--- a/tests/internal_check.cpp
+++ b/tests/internal_check.cpp
@@ -1,0 +1,47 @@
+/*
+* Copyright (C) 2020 German Aerospace Center (DLR/SC)
+*
+* Created: 2020-07-17 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h" // Brings in the GTest framework
+#include "tixi.h"
+#include "tixiInternal.h"
+
+TEST(InternalCheck, getChildNodeCount)
+{
+    TixiDocumentHandle handle = 0;
+
+    ASSERT_EQ(SUCCESS, tixiOpenDocument("TestData/textelements.xml", &handle));
+    TixiDocument *document = getDocument(handle);
+
+    xmlNodePtr element = NULL;
+    ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root", &element));
+    EXPECT_EQ(2, getChildNodeCount(element));
+
+    ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root/a", &element));
+    EXPECT_EQ(1, getChildNodeCount(element));
+
+    ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root/a/text()", &element));
+    EXPECT_EQ(0, getChildNodeCount(element));
+
+    ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root/b", &element));
+    EXPECT_EQ(3, getChildNodeCount(element));
+
+    ASSERT_EQ(SUCCESS, checkElement(document->xpathContext, "/root/b/c", &element));
+    EXPECT_EQ(1, getChildNodeCount(element));
+
+    tixiCloseDocument(handle);
+}

--- a/tests/textelements_check.cpp
+++ b/tests/textelements_check.cpp
@@ -70,3 +70,11 @@ TEST_F(GetTextElementTests, multipleTextNodes)
 
     EXPECT_EQ(SUCCESS, tixiCheckElement(documentHandle, "/root/b/text()[1]"));
 }
+
+TEST_F(GetTextElementTests, specialChars)
+{
+    char* text = NULL;
+    tixiAddTextElement(documentHandle, "/root", "c", "'bad < text ! &");
+    EXPECT_EQ(SUCCESS, tixiGetTextElement(documentHandle, "/root/c", &text));
+    EXPECT_STREQ("'bad < text ! &", text);
+}

--- a/tests/textelements_check.cpp
+++ b/tests/textelements_check.cpp
@@ -69,6 +69,9 @@ TEST_F(GetTextElementTests, multipleTextNodes)
     EXPECT_EQ(2, count);
 
     EXPECT_EQ(SUCCESS, tixiCheckElement(documentHandle, "/root/b/text()[1]"));
+
+    EXPECT_EQ(SUCCESS, tixiGetTextElement(documentHandle, "/root/d", &text));
+    EXPECT_STREQ("", text);
 }
 
 TEST_F(GetTextElementTests, specialChars)


### PR DESCRIPTION
Libxml automatically unescapes special characters, if we use the function ``xmlNodeGetContent``.

Before this fix, getting a text element "/root/c" was using another function ``xmlNodeListGetString`` as ``/root/c`` is not the text element in an XPATH meaning. The correct path to the text element would have been ``/root/c/text()``.

To be consistent with tixi's behaviour, I now check whether ``/root/c`` contains only one text element. If this is the case, I return the node content via ``xmlNodeGetContent``.

Fixes #107