### PR TITLE
Fixed crash when printing too long status messages

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -58,18 +58,23 @@ TixiPrintMsgFnc tixiMessageHandler = tixiDefaultMessageHandler;
  */
 TIXI_INTERNAL_EXPORT void printMsg(MessageType type, const char* message, ...)
 {
-  char buffer[2048];
+  #define BUFFER_SIZE 2048
+  char buffer[BUFFER_SIZE];
   char* extra = NULL;
   int len = 0;
 
   va_list varArgs;
   va_start(varArgs, message);
-  if ((len = vsnprintf(buffer, 2048, message, varArgs)) >= 2048) {
-    // message is longer than 2048 bytes,
-    // we must allocate
+  len = vsnprintf(buffer, BUFFER_SIZE, message, varArgs);
+  va_end(varArgs);
+  if (len >= BUFFER_SIZE) {
+    // message is longer than BUFFER_SIZE bytes,
+    // we must allocate dynamically
     extra = (char*) malloc((len+1) * sizeof(char));
 
+    va_start(varArgs, message);
     vsnprintf(extra, len+1, message, varArgs);
+    va_end(varArgs);
     if (tixiMessageHandler) {
       tixiMessageHandler(type, extra);
     }
@@ -84,7 +89,7 @@ TIXI_INTERNAL_EXPORT void printMsg(MessageType type, const char* message, ...)
     }
   }
 
-  va_end(varArgs);
+
 }
 
 int _initialized = 0;

--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -56,7 +56,7 @@ TixiPrintMsgFnc tixiMessageHandler = tixiDefaultMessageHandler;
 /**
   Route all messages to the internal message handler
  */
-void printMsg(MessageType type, const char* message, ...)
+TIXI_INTERNAL_EXPORT void printMsg(MessageType type, const char* message, ...)
 {
   char buffer[2048];
   char* extra = NULL;

--- a/tests/test_bugs.cpp
+++ b/tests/test_bugs.cpp
@@ -64,3 +64,16 @@ TEST(Bugs, empty_textelement)
   ASSERT_EQ(SUCCESS, tixiGetTextElement(handle, "/Root/TextEl2", &text));
   ASSERT_STREQ("mytext2", text);
 }
+
+extern "C" void printMsg(MessageType type, const char* message, ...);
+
+TEST(Bugs, printMessageCrash)
+{
+    char msg[3000];
+    for (int i = 0; i < 3000; ++i) {
+        msg[i] = 'a';
+    }
+    msg[2999] = '\0';
+
+    printMsg(MESSAGETYPE_ERROR, "%s", msg);
+}


### PR DESCRIPTION
We still do not disable printing long messages when loading an invalid xml file. This could be handled in a separate PR if required.

I reproduced and verified the issue with valgrind. After the fix, valgrind shows no errors enymore.

This commit fixes #108 