### PR TITLE
Make utility function IsNumeric return true for numeric strings with trailing whitespace

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -891,6 +891,7 @@ DLL_EXPORT ReturnCode tixiGetIntegerElement(const TixiDocumentHandle handle, con
     return error;
   }
 
+  trim_trailing_whitespace(text);
   if (isNumeric(text)) {
     *number = atoi(text);
     return SUCCESS;
@@ -911,7 +912,7 @@ DLL_EXPORT ReturnCode tixiGetDoubleElement(const TixiDocumentHandle handle, cons
     printMsg(MESSAGETYPE_STATUS, "Error: tixiGetTextElement returns %d in tixiGetDoubleElement.\n", error);
     return error;
   }
-
+  trim_trailing_whitespace(text);
   if (isNumeric(text)) {
     *number = atof(text);
     return SUCCESS;

--- a/src/tixiUtils.c
+++ b/src/tixiUtils.c
@@ -410,37 +410,26 @@ char *substring(const char *str, int start_pos, int end_pos)
 int isNumeric (const char * s)
 {
     char * p;
-    char * s_trimmed;
-    s_trimmed = trim_trailing_whitespace(s);
 
-    if (s_trimmed == NULL || *s_trimmed == '\0') {
+    if (s == NULL || *s == '\0') {
       return 0;
     }
 
-    strtod (s_trimmed, &p);
+    strtod (s, &p);
     return *p == '\0';
 }
 
-char* trim_trailing_whitespace(const char *str)
+void trim_trailing_whitespace(char *str)
 {
-    int i = 0;
-    int j = 0;
-    int len = 0;
-    char *out = 0;
-
-    len = strlen(str);
-    out = malloc(len + 1);
+    int i;
+    int len = strlen(str);
 
     i = len-1;
-    while( (str[i] == ' ' || str[i] == '\t' || str[i] == '\n') && i >= 0)
+    while( i >= 0 && isspace(str[i]))
     {
         i--;
     }
-
-    for( j=0; j<i+1; j++) {
-        out[j]=str[j];
+    if ( i < len-1 ) {
+        str[i+1]= '\0';
     }
-    out[i+1]= '\0';
-
-    return out;
 }

--- a/src/tixiUtils.c
+++ b/src/tixiUtils.c
@@ -410,11 +410,37 @@ char *substring(const char *str, int start_pos, int end_pos)
 int isNumeric (const char * s)
 {
     char * p;
+    char * s_trimmed;
+    s_trimmed = trim_trailing_whitespace(s);
 
-    if (s == NULL || *s == '\0') {
+    if (s_trimmed == NULL || *s_trimmed == '\0') {
       return 0;
     }
 
-    strtod (s, &p);
+    strtod (s_trimmed, &p);
     return *p == '\0';
+}
+
+char* trim_trailing_whitespace(const char *str)
+{
+    int i = 0;
+    int j = 0;
+    int len = 0;
+    char *out = 0;
+
+    len = strlen(str);
+    out = malloc(len + 1);
+
+    i = len-1;
+    while( (str[i] == ' ' || str[i] == '\t' || str[i] == '\n') && i >= 0)
+    {
+        i--;
+    }
+
+    for( j=0; j<i+1; j++) {
+        out[j]=str[j];
+    }
+    out[i+1]= '\0';
+
+    return out;
 }

--- a/src/tixiUtils.h
+++ b/src/tixiUtils.h
@@ -181,6 +181,14 @@ TIXI_INTERNAL_EXPORT char* stringToLower(char* string);
 TIXI_INTERNAL_EXPORT int isNumeric (const char * s);
 
 /**
+  @brief strips any trailing whitespace from a string
+  @param char str (in) The source string
+  @return
+    a string without trailing whitespace
+ */
+TIXI_INTERNAL_EXPORT char* trim_trailing_whitespace(const char * str);
+
+/**
   @brief Strips the first len bytes of the string.
   @param char string (in)  The source string
   @param int n       (in)  The number of bytes to strip from s2

--- a/src/tixiUtils.h
+++ b/src/tixiUtils.h
@@ -181,12 +181,10 @@ TIXI_INTERNAL_EXPORT char* stringToLower(char* string);
 TIXI_INTERNAL_EXPORT int isNumeric (const char * s);
 
 /**
-  @brief strips any trailing whitespace from a string
+  @brief strips any trailing whitespace from a string in place
   @param char str (in) The source string
-  @return
-    a string without trailing whitespace
  */
-TIXI_INTERNAL_EXPORT char* trim_trailing_whitespace(const char * str);
+TIXI_INTERNAL_EXPORT void trim_trailing_whitespace(char * str);
 
 /**
   @brief Strips the first len bytes of the string.

--- a/tests/TestData/in.xml
+++ b/tests/TestData/in.xml
@@ -198,4 +198,7 @@
         <aBool2b>0</aBool2b>
         <aBool3b>-1</aBool3b>
     </bool>
+    <doubleWithExcessWhitespace>3.145 </doubleWithExcessWhitespace>
+    <intWithExcessWhitespace>  42  </intWithExcessWhitespace>
+
 </plane>

--- a/tests/get_element_check.cpp
+++ b/tests/get_element_check.cpp
@@ -203,6 +203,18 @@ TEST_F(GetElementTests, getMatrixOfPoints)
   }
 }
 
+TEST_F(GetElementTests, bug_160)
+{
+    int my_int = 0;
+    double my_double = 0;
+
+    EXPECT_TRUE( tixiGetDoubleElement( documentHandle, "/plane/doubleWithExcessWhitespace", &my_double) == SUCCESS );
+    EXPECT_NEAR( my_double, 3.145, 1e-12);
+
+    EXPECT_TRUE( tixiGetIntegerElement( documentHandle, "/plane/intWithExcessWhitespace", &my_int) == SUCCESS );
+    EXPECT_EQ( my_int, 42);
+}
+
 TEST_F(GetElementTests, GetChildElements)
 {
   char* string;

--- a/tests/utils_check.cpp
+++ b/tests/utils_check.cpp
@@ -133,30 +133,33 @@ TEST(UtilsTest, substring)
 
 TEST(UtilsTest, trim_trailing_whitespace)
 {
-    const char* str_in1 = "  test  ";
-    const char* str_in2 = "test  ";
-    const char* str_in3 = "";
-    const char* str_in4 = " ";
-    const char* str_in5 = "test \n";
-    const char* str_in6 = "test\t";
+    char* str = (char*)malloc(sizeof(char)*128);
 
-    char* str_out1 = trim_trailing_whitespace(str_in1);
-    ASSERT_STREQ(str_out1, "  test");
+    sprintf(str, "%s", "  test  ");
+    trim_trailing_whitespace(str);
+    ASSERT_STREQ(str, "  test");
 
-    char* str_out2 = trim_trailing_whitespace(str_in2);
-    ASSERT_STREQ(str_out2, "test");
+    sprintf(str, "%s", "test  ");
+    trim_trailing_whitespace(str);
+    ASSERT_STREQ(str, "test");
 
-    char* str_out3 = trim_trailing_whitespace(str_in3);
-    ASSERT_STREQ(str_out3, "");
+    sprintf(str, "%s", "");
+    trim_trailing_whitespace(str);
+    ASSERT_STREQ(str, "");
 
-    char* str_out4 = trim_trailing_whitespace(str_in4);
-    ASSERT_STREQ(str_out4, "");
+    sprintf(str, "%s", " ");
+    trim_trailing_whitespace(str);
+    ASSERT_STREQ(str, "");
 
-    char* str_out5 = trim_trailing_whitespace(str_in5);
-    ASSERT_STREQ(str_out5, "test");
+    sprintf(str, "%s", "test \n");
+    trim_trailing_whitespace(str);
+    ASSERT_STREQ(str, "test");
 
-    char* str_out6 = trim_trailing_whitespace(str_in6);
-    ASSERT_STREQ(str_out6, "test");
+    sprintf(str, "%s", "test\t");
+    trim_trailing_whitespace(str);
+    ASSERT_STREQ(str, "test");
+
+    free(str);
 }
 
 TEST(UtilsTest, isPathRelative)

--- a/tests/utils_check.cpp
+++ b/tests/utils_check.cpp
@@ -25,19 +25,8 @@
 
 static TixiDocumentHandle documentHandle = -1;
 
-class UtilsTest : public ::testing::Test
-{
-protected:
-  virtual void SetUp()
-  {
-  }
 
-  virtual void TearDown()
-  {
-  }
-};
-
-TEST_F(UtilsTest, string_stripLeft)
+TEST(UtilsTest, string_stripLeft)
 {
   const char* mystring = "    my new string";
   char* newstring = NULL;
@@ -46,7 +35,7 @@ TEST_F(UtilsTest, string_stripLeft)
   free(newstring);
 }
 
-TEST_F(UtilsTest, string_stripLeft_error)
+TEST(UtilsTest, string_stripLeft_error)
 {
 
   const char* mystring = " string";
@@ -54,7 +43,7 @@ TEST_F(UtilsTest, string_stripLeft_error)
   ASSERT_EQ(NULL,newstring);
 }
 
-TEST_F(UtilsTest, my_strncasecmp)
+TEST(UtilsTest, my_strncasecmp)
 {
   const char* a = "string1";
   const char* b = "string1";
@@ -69,7 +58,7 @@ TEST_F(UtilsTest, my_strncasecmp)
 
 }
 
-TEST_F(UtilsTest, my_strncasecmp_invalid )
+TEST(UtilsTest, my_strncasecmp_invalid )
 {
   const char* a = "string1";
   const char* b = "string1";
@@ -79,7 +68,7 @@ TEST_F(UtilsTest, my_strncasecmp_invalid )
   ASSERT_EQ(0, my_strncasecmp(a,b,10));
 }
 
-TEST_F(UtilsTest, create_local_directory)
+TEST(UtilsTest, create_local_directory)
 {
 
   const char* path = "tmp/";
@@ -89,7 +78,8 @@ TEST_F(UtilsTest, create_local_directory)
   rmdir(path);
 
 }
-TEST_F(UtilsTest, create_local_directory_failed)
+
+TEST(UtilsTest, create_local_directory_failed)
 {
 
   const char* path = "tmp2/temp2";
@@ -98,7 +88,7 @@ TEST_F(UtilsTest, create_local_directory_failed)
 
 }
 
-TEST_F(UtilsTest, string_startsWith)
+TEST(UtilsTest, string_startsWith)
 {
   const char* a = "string1";
   const char* b = "str";
@@ -109,7 +99,7 @@ TEST_F(UtilsTest, string_startsWith)
   ASSERT_EQ(-1, string_startsWith(a, c));
 }
 
-TEST_F(UtilsTest, string_endsWith)
+TEST(UtilsTest, string_endsWith)
 {
   ASSERT_EQ( 0, string_endsWith("string1", "ing1"));
   ASSERT_EQ( 0, string_endsWith("string1", "1"));
@@ -120,7 +110,7 @@ TEST_F(UtilsTest, string_endsWith)
   ASSERT_EQ(-1, string_endsWith("string1", "bla"));
 }
 
-TEST_F(UtilsTest, substring)
+TEST(UtilsTest, substring)
 {
   const char* mystring = "Hallo Welt";
   char* result = NULL;
@@ -141,7 +131,35 @@ TEST_F(UtilsTest, substring)
   result = NULL;
 }
 
-TEST_F(UtilsTest, isPathRelative)
+TEST(UtilsTest, trim_trailing_whitespace)
+{
+    const char* str_in1 = "  test  ";
+    const char* str_in2 = "test  ";
+    const char* str_in3 = "";
+    const char* str_in4 = " ";
+    const char* str_in5 = "test \n";
+    const char* str_in6 = "test\t";
+
+    char* str_out1 = trim_trailing_whitespace(str_in1);
+    ASSERT_STREQ(str_out1, "  test");
+
+    char* str_out2 = trim_trailing_whitespace(str_in2);
+    ASSERT_STREQ(str_out2, "test");
+
+    char* str_out3 = trim_trailing_whitespace(str_in3);
+    ASSERT_STREQ(str_out3, "");
+
+    char* str_out4 = trim_trailing_whitespace(str_in4);
+    ASSERT_STREQ(str_out4, "");
+
+    char* str_out5 = trim_trailing_whitespace(str_in5);
+    ASSERT_STREQ(str_out5, "test");
+
+    char* str_out6 = trim_trailing_whitespace(str_in6);
+    ASSERT_STREQ(str_out6, "test");
+}
+
+TEST(UtilsTest, isPathRelative)
 {
   // check relative path
   ASSERT_EQ(0, isPathRelative("file://tmp"));
@@ -154,7 +172,7 @@ TEST_F(UtilsTest, isPathRelative)
   ASSERT_NE(0, isPathRelative("usr/local"));
 }
 
-TEST_F(UtilsTest, isLocalPathRelative)
+TEST(UtilsTest, isLocalPathRelative)
 {
   ASSERT_EQ(0, isLocalPathRelative("./test.txt"));
 
@@ -170,7 +188,7 @@ TEST_F(UtilsTest, isLocalPathRelative)
 #endif
 }
 
-TEST_F(UtilsTest, isURIPath)
+TEST(UtilsTest, isURIPath)
 {
   ASSERT_EQ(0, isURIPath("file://test.txt"));
   ASSERT_EQ(0, isURIPath("file:///data/test.txt"));
@@ -187,12 +205,12 @@ TEST_F(UtilsTest, isURIPath)
   ASSERT_EQ(1, isURIPath("/home/user/data.txt"));
 }
 
-TEST_F(UtilsTest, isPathRelative_invalidPath)
+TEST(UtilsTest, isPathRelative_invalidPath)
 {
   ASSERT_NE(0, isPathRelative(NULL));
 }
 
-TEST_F(UtilsTest, uriToLocalPath)
+TEST(UtilsTest, uriToLocalPath)
 {
   char* result = NULL;
 
@@ -216,7 +234,7 @@ TEST_F(UtilsTest, uriToLocalPath)
   ASSERT_EQ(NULL, result);
 }
 
-TEST_F(UtilsTest, localPathToURI)
+TEST(UtilsTest, localPathToURI)
 {
   char* result = NULL;
 
@@ -241,7 +259,7 @@ TEST_F(UtilsTest, localPathToURI)
   free(result);
 }
 
-TEST_F(UtilsTest, loadFileToString)
+TEST(UtilsTest, loadFileToString)
 {
   const char* expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<root/>\n";
   char* string = loadFileToString("TestData/minimal.xml");
@@ -250,7 +268,7 @@ TEST_F(UtilsTest, loadFileToString)
 }
 
 
-TEST_F(UtilsTest, stripDirName)
+TEST(UtilsTest, stripDirName)
 {
   char* dir, *file;
 #ifdef _WIN32
@@ -314,7 +332,7 @@ TEST_F(UtilsTest, stripDirName)
   strip_dirname(NULL, &dir, &file);
 }
 
-TEST_F(UtilsTest, resolveDirectory)
+TEST(UtilsTest, resolveDirectory)
 {
   char* dir = NULL;
   dir = resolveDirectory("TestData/", "file://Data");


### PR DESCRIPTION
Since recently, we have the `isNumeric` check in `tixiGetDoubleElement` and `tixiGetIntegerElement` so that an error is returned for nonnumeric strings. However, `IsNumeric` also returned an error for strings that are numeric but contain trailing whitespaces. With this PR, trailing white spaces are ignored in the check.

Fixes #160
Addresses DLR-SC/tigl#710