### PR TITLE
Fixed crash when save document with external nodes

### DIFF
--- a/src/tixiInternal.c
+++ b/src/tixiInternal.c
@@ -771,7 +771,7 @@ xmlNodePtr createExternalNode(const char* urlPath, const char* filename)
         xmlAddChild( filenameNode, filenameNodeText );
     }
 
-   return externalNode;
+    return externalNode;
 }
 
 ReturnCode saveExternalFiles(xmlNodePtr aNodePtr, TixiDocument* aTixiDocument)

--- a/src/tixiInternal.h
+++ b/src/tixiInternal.h
@@ -254,6 +254,14 @@ TIXI_INTERNAL_EXPORT ReturnCode openExternalFiles(TixiDocument* aTixiDocument, i
  */
 TIXI_INTERNAL_EXPORT void removeExternalNodeLinks(xmlNodePtr aNodePtr);
 
+/**
+ * @brief Creates an external file xml node
+ *
+ * @param urlPath  The path / directory of the file
+ * @param filename The filename
+ * @return Xml node pointer containing the node structure.
+ */
+TIXI_INTERNAL_EXPORT xmlNodePtr createExternalNode(const char* urlPath, const char* filename);
 
 /**
   @brief Searches the tree for node that have to be saved in external files again.

--- a/tests/TestData/ElasticityEvolutionInclude.xml
+++ b/tests/TestData/ElasticityEvolutionInclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<elasticityEvolution name="5b29606d-c2dd-4f86-8594-4e057fb6df44">
+  <model xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="d57a6369-4b41-4254-8ffd-e895970ff865" xsi:type="constantElasticityEvolutionModel">
+    <externaldata>
+      <path>file://.</path>
+      <filename>ElasticityEvolutionValue.xml</filename>
+    </externaldata>
+  </model>
+</elasticityEvolution>

--- a/tests/TestData/ElasticityEvolutionValue.xml
+++ b/tests/TestData/ElasticityEvolutionValue.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="5042895a-8150-4fbc-8f5a-43cd6c0ccca7" xsi:type="isotropicLinearElasticity">
+   <e>70000.0</e>
+   <nu>0.33</nu>
+</value>

--- a/tests/savedocument_check.cpp
+++ b/tests/savedocument_check.cpp
@@ -64,6 +64,15 @@ TEST_F(SaveDocumentCheck, saveWithoutNodeLinks)
 
     ASSERT_EQ(SUCCESS, tixiSaveDocument(handle, "save-without-links.xml"));
 
-
 }
 
+
+TEST(SaveDocumentCheckRecursive, saveSplittedRecursive)
+{
+    TixiDocumentHandle handle;
+    ASSERT_EQ(SUCCESS, tixiOpenDocumentRecursive("TestData/ElasticityEvolutionInclude.xml", &handle, OPENMODE_RECURSIVE));
+    EXPECT_EQ(SUCCESS, tixiCheckElement(handle, "/elasticityEvolution/model/value/e"));
+    EXPECT_EQ(SUCCESS, tixiCheckElement(handle, "/elasticityEvolution/model/value/nu"));
+    ASSERT_EQ(SUCCESS, tixiSaveDocument(handle, "Splitted.xml"));
+    ASSERT_EQ (SUCCESS, tixiCloseDocument( handle ));
+}


### PR DESCRIPTION
This PR fixes the issue regarding the crash when saving external nodes.

Before, the node order could have been changed when storing the external files, as the external nodes will be created at the end of the child node list of the current parent.

Now, the external node is created and the content is now replaced with the external node.

Fixes #175 