### PR TITLE
Improved performance of tixiAdd/UpdateFloatVector

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -1532,37 +1532,12 @@ DLL_EXPORT ReturnCode tixiAddFloatVector (const TixiDocumentHandle handle, const
   ReturnCode error;
   char *stringVector = NULL;
   char *textBuffer = NULL;
-  int i;
-  int stringSize = 0;
 
   if (!format) {
     format = "%g";
   };
 
-  /* calculate the size of the resulting string */
-  for(i=0; i<numElements; i++) {
-    textBuffer = buildString(format, vector[i]);
-    stringSize += (int) strlen(textBuffer);
-    free(textBuffer);
-  }
-
-  /* allocate memory */
-  stringVector = (char *) malloc(sizeof(char) * (stringSize + numElements + 1));
-
-  /* copy strings to stringVector */
-  stringVector[0] = '\0';
-
-  if (numElements>0) {
-      textBuffer = buildString(format, vector[0]);
-      strcat(stringVector, textBuffer);
-      free(textBuffer);
-      for(i=1; i<numElements; i++) {
-        textBuffer = buildString(format, vector[i]);
-        strcat(stringVector, VECTOR_SEPARATOR);
-        strcat(stringVector, textBuffer);
-        free(textBuffer);
-      }
-  }
+  stringVector = vectorToString(vector, numElements, format);
 
   /* Add element */
   error = tixiAddTextElement(handle, parentPath, elementName, stringVector);
@@ -1590,9 +1565,6 @@ DLL_EXPORT ReturnCode tixiUpdateFloatVector (const TixiDocumentHandle handle, co
 {
   ReturnCode error;
   char *stringVector = NULL;
-  char *textBuffer = NULL;
-  int i;
-  int stringSize = 0;
 
   if(numElements < 1) {
     return FAILED;
@@ -1602,27 +1574,7 @@ DLL_EXPORT ReturnCode tixiUpdateFloatVector (const TixiDocumentHandle handle, co
     format = "%g";
   };
 
-  /* calculate the size of the resulting string */
-  for(i=0; i<numElements; i++) {
-    textBuffer = buildString(format, vector[i]);
-    stringSize += (int) strlen(textBuffer);
-    free(textBuffer);
-  }
-
-  /* allocate memory */
-  stringVector = (char *) malloc(sizeof(char) * (stringSize + numElements + 1));
-
-  /* copy strings to stringVector */
-  stringVector[0] = '\0';
-  textBuffer = buildString(format, vector[0]);
-  strcat(stringVector, textBuffer);
-  free(textBuffer);
-  for(i=1; i<numElements; i++) {
-    textBuffer = buildString(format, vector[i]);
-    strcat(stringVector, VECTOR_SEPARATOR);
-    strcat(stringVector, textBuffer);
-    free(textBuffer);
-  }
+  stringVector = vectorToString(vector, numElements, format);
 
   error = tixiUpdateTextElement(handle, path, stringVector);
   free(stringVector);

--- a/src/tixiInternal.c
+++ b/src/tixiInternal.c
@@ -563,6 +563,46 @@ char* buildString(const char* format, ...)
   return buffer;
 }
 
+char* vectorToString(const double* vector, int numElements, const char* format)
+{
+    int i = 0, stringSize = 0, delim_size = strlen(VECTOR_SEPARATOR);
+    char* textBuffer = NULL;
+    // the output string
+    char* stringVector = NULL;
+
+    /* calculate the size of the resulting string */
+    for (i=0; i<numElements; i++) {
+      textBuffer = buildString(format, vector[i]);
+      stringSize += (int) strlen(textBuffer) + delim_size;
+      free(textBuffer);
+    }
+
+    /* allocate memory */
+    stringVector = (char *) malloc(sizeof(char) * (stringSize + 1));
+
+    /* copy strings to stringVector */
+    stringVector[0] = '\0';
+
+    if (numElements>0) {
+        textBuffer = buildString(format, vector[0]);
+        strcat(stringVector, textBuffer);
+        stringSize = (int) strlen(textBuffer);
+        free(textBuffer);
+        for(i=1; i<numElements; i++) {
+
+          textBuffer = buildString(format, vector[i]);
+          // by using the pointer stringVector + stringSize, we can avoid
+          // computing the string length as done by strcat
+          sprintf(stringVector + stringSize,"%s%s" , VECTOR_SEPARATOR, textBuffer);
+
+          stringSize += (int) strlen(textBuffer) + delim_size;
+          free(textBuffer);
+        }
+    }
+
+    return stringVector;
+}
+
 char* loadExternalFileToString(const char* filename)
 {
   if (isURIPath(filename) != 0) {

--- a/src/tixiInternal.h
+++ b/src/tixiInternal.h
@@ -206,6 +206,11 @@ TIXI_INTERNAL_EXPORT void checkLibxml2Version();
 */
 TIXI_INTERNAL_EXPORT char* buildString(const char* format, ...);
 
+/**
+  @brief Converts a float vector into the cpacs string representation using the
+  given formatting rule
+*/
+TIXI_INTERNAL_EXPORT char* vectorToString(const double* floatVec, int numElements, const char* format);
 
 /**
   @brief Open external xml files and merge them into the tree.

--- a/tests/vector_check.cpp
+++ b/tests/vector_check.cpp
@@ -18,6 +18,7 @@
 
 #include "test.h" // Brings in the GTest framework
 #include "tixi.h"
+#include "tixiInternal.h"
 
 
 /**
@@ -118,4 +119,40 @@ TEST_F(VectorTests, tixiUpdateVectorTests)
   ASSERT_TRUE ( tixiUpdateFloatVector(documentHandleAdd, "/a/test_not_there", pointsUpdated, count, "%f") == ELEMENT_NOT_FOUND);
   ASSERT_TRUE ( tixiUpdateFloatVector(-1, "/a/test", pointsUpdated, count, "%f") == INVALID_HANDLE );
   ASSERT_TRUE ( tixiUpdateFloatVector(documentHandleAdd, "/a/test", pointsUpdated, 0, "%f") == FAILED );
+}
+
+// Make sure to run in a reasoble time
+TEST(Vector, Performance)
+{
+    TixiDocumentHandle handle;
+    ASSERT_EQ(SUCCESS, tixiCreateDocument("root", &handle));
+
+    int n = 40000;
+
+    double* vec = new double[n];
+
+    for (int i = 0; i < n; ++i) {
+        vec[i] = (float)i;
+    }
+
+    EXPECT_EQ(SUCCESS, tixiAddFloatVector(handle, "/root", "myvec", vec, n, "%f"));
+
+    delete [] vec;
+
+    tixiCloseDocument(handle);
+}
+
+TEST(Vector, vectorToString)
+{
+    int n = 10;
+    double* vec = new double[n];
+    char* myvecString = NULL;
+
+    for (int i = 0; i < n; ++i) vec[i] = (float)i;
+
+    myvecString = vectorToString(vec, n, "%.2f");
+
+    EXPECT_STREQ("0.00;1.00;2.00;3.00;4.00;5.00;6.00;7.00;8.00;9.00", myvecString);
+
+    delete [] vec;
 }


### PR DESCRIPTION
The problem before was the call to strcat, which constantly had to compute the string length of the string to be concatenated to. This led to a O(n²) behavior.

Now, we simply store the location to insert the string. No need to compute the length. Now, we have linear behaviour with much smaller runtimes (up to a factor of 1000 faster) for very large vectors

Closes #183