### PR TITLE
Changed tixiAddExternalLink to be consistent

### DIFF
--- a/src/tixi.h
+++ b/src/tixi.h
@@ -2488,18 +2488,28 @@ DLL_EXPORT ReturnCode tixiDeclareNamespace(const TixiDocumentHandle handle, cons
 
 
 /**
-  @brief Add a name of an external file as a url.
+  @brief Adds a link to an external xml file
+
+  The file is linked in the XML as
+
+  @verbatim
+  <externaldata>
+        <path>https://dlr.de/myxmlstore</path>
+        <filename>externaldata-included-1.xml</filename>
+  </externaldata>
+  @endverbatim
+
+  Note: the linked external file is not automatically loaded into the document.
 
   <b>Fortran syntax:</b>
 
-  tixi_add_external_link( integer  handle, character*n parent_path, character*n url, character*n file_format, integer error )
+  tixi_add_external_link( integer  handle, character*n parent_path, character*n path, character*n filename, integer error )
 
   @param[in]  handle as returned by ::tixiCreateDocument
-  @param[in]  parentPath path to the element into which the element holding the url
+  @param[in]  parentPath The Path to the element into which the element holding the url
                          should be inserted.
-  @param[in]  url an url to specify an additional output file not in XML-format
-  @param[in]  fileFormat an optional attribute (may be NULL) to specify a file format,
-                         e.g. CNGS, netcdf, ...
+  @param[in]  pathOrUrl The parent path or url to the file.
+  @param[in]  filename The actual name of the xml file.
 
   @return
     - SUCCESS if successfully added the header
@@ -2508,7 +2518,7 @@ DLL_EXPORT ReturnCode tixiDeclareNamespace(const TixiDocumentHandle handle, cons
     - ALREADY_SAVED if the header should be added to an already saved document
  */
 DLL_EXPORT ReturnCode tixiAddExternalLink (const TixiDocumentHandle handle, const char *parentPath,
-                                           const char *url, const char *fileFormat);
+                                           const char *pathOrUrl, const char *filename);
 
 
 /**

--- a/src/tixi.h
+++ b/src/tixi.h
@@ -387,6 +387,22 @@ enum OpenMode
 
 
 typedef enum OpenMode OpenMode;
+/**
+
+\ingroup Enums
+     Mode how to add external data nodes to the document.
+
+ Has a typedef to AddLinkMode.
+  */
+enum AddLinkMode
+{
+  ADDLINK_CREATE,                   /*!< Just create the link. The files won't be load into the document. */
+  ADDLINK_CREATE_AND_OPEN           /*!< Creates the link and loads the specified file into the document. */
+};
+
+
+typedef enum AddLinkMode AddLinkMode;
+
 
 /**
 
@@ -2510,6 +2526,7 @@ DLL_EXPORT ReturnCode tixiDeclareNamespace(const TixiDocumentHandle handle, cons
                          should be inserted.
   @param[in]  pathOrUrl The parent path or url to the file.
   @param[in]  filename The actual name of the xml file.
+  @param[in]  mode Mode whether to create only the link or load the files into the document.
 
   @return
     - SUCCESS if successfully added the header
@@ -2518,7 +2535,7 @@ DLL_EXPORT ReturnCode tixiDeclareNamespace(const TixiDocumentHandle handle, cons
     - ALREADY_SAVED if the header should be added to an already saved document
  */
 DLL_EXPORT ReturnCode tixiAddExternalLink (const TixiDocumentHandle handle, const char *parentPath,
-                                           const char *pathOrUrl, const char *filename);
+                                           const char *pathOrUrl, const char *filename, AddLinkMode mode);
 
 
 /**

--- a/src/tixiInternal.h
+++ b/src/tixiInternal.h
@@ -252,6 +252,18 @@ TIXI_INTERNAL_EXPORT char* vectorToString(const double* floatVec, int numElement
 */
 TIXI_INTERNAL_EXPORT ReturnCode openExternalFiles(TixiDocument* aTixiDocument, int* number);
 
+/**
+ * @brief Loads all files into the document given a external data node
+ *
+ * @param aTixiDocument (in) A TIXI document with a opened main-xml file.
+ * @param externalDataNode (in) A pointer to the external data node.
+ * @param fileCounter (out) File counter pointer to enable counting the number of opened files.
+ * @return
+    - SUCCESS
+    - FAILED internal error
+    - OPEN_FAILED
+ */
+TIXI_INTERNAL_EXPORT ReturnCode loadExternalDataNode(TixiDocument* aTixiDocument, xmlNodePtr externalDataNode, int* fileCounter);
 
 /**
  * @brief Remove all links to external files

--- a/tests/other_check.cpp
+++ b/tests/other_check.cpp
@@ -135,18 +135,12 @@ TEST_F(OtherTests, childCount_twoChildren)
   ASSERT_TRUE( count == 2 );
 }
 
-TEST_F(OtherTests, addExternalLink_withAttribute)
+TEST_F(OtherTests, addExternalLink)
 {
   const char* parentPath = "/root";
-  ASSERT_TRUE( tixiAddExternalLink( outDocumentHandle, parentPath, "TestData/externalFile1", "MyFormat" ) == SUCCESS );
+  ASSERT_EQ(SUCCESS, tixiAddExternalLink( outDocumentHandle, parentPath, "./", "externaldata-included-1.xml" ));
+  ASSERT_EQ(ELEMENT_NOT_FOUND, tixiAddExternalLink( outDocumentHandle, "/invalidroot", "./", "externaldata-included-1.xml" ));
 }
-
-TEST_F(OtherTests, addExternalLink_withoutAttribute)
-{
-  const char* parentPath = "/root";
-  ASSERT_TRUE( tixiAddExternalLink( outDocumentHandle, parentPath, "TestData/externalFile2", NULL ) == SUCCESS );
-}
-
 
 TEST_F(OtherTests, usePrettyPrint)
 {

--- a/tests/other_check.cpp
+++ b/tests/other_check.cpp
@@ -135,11 +135,52 @@ TEST_F(OtherTests, childCount_twoChildren)
   ASSERT_TRUE( count == 2 );
 }
 
-TEST_F(OtherTests, addExternalLink)
+TEST_F(OtherTests, addExternalLink_Create)
 {
   const char* parentPath = "/root";
-  ASSERT_EQ(SUCCESS, tixiAddExternalLink( outDocumentHandle, parentPath, "./", "externaldata-included-1.xml" ));
-  ASSERT_EQ(ELEMENT_NOT_FOUND, tixiAddExternalLink( outDocumentHandle, "/invalidroot", "./", "externaldata-included-1.xml" ));
+
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata/path"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata/filename"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/testNode"));
+
+  ASSERT_EQ(SUCCESS, tixiAddExternalLink( outDocumentHandle, parentPath, "TestData", "externaldata-included-1.xml", ADDLINK_CREATE ));
+
+  EXPECT_EQ(SUCCESS, tixiCheckElement(outDocumentHandle, "/root/externaldata"));
+  EXPECT_EQ(SUCCESS, tixiCheckElement(outDocumentHandle, "/root/externaldata/path"));
+  EXPECT_EQ(SUCCESS, tixiCheckElement(outDocumentHandle, "/root/externaldata/filename"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/testNode"));
+
+}
+
+TEST_F(OtherTests, addExternalLink_CreateAndOpen)
+{
+  const char* parentPath = "/root";
+
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata/path"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata/filename"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/testNode"));
+
+  ASSERT_EQ(SUCCESS, tixiAddExternalLink( outDocumentHandle, parentPath, "TestData", "externaldata-included-1.xml", ADDLINK_CREATE_AND_OPEN ));
+
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata/path"));
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiCheckElement(outDocumentHandle, "/root/externaldata/filename"));
+  EXPECT_EQ(SUCCESS, tixiCheckElement(outDocumentHandle, "/root/testNode"));
+}
+
+TEST_F(OtherTests, addExternalLink_Errors)
+{
+  const char* parentPath = "/root";
+
+  EXPECT_EQ(FAILED, tixiAddExternalLink( outDocumentHandle, NULL, "TestData", "externaldata-included-1.xml", ADDLINK_CREATE_AND_OPEN ));
+  EXPECT_EQ(FAILED, tixiAddExternalLink( outDocumentHandle, parentPath, NULL, "externaldata-included-1.xml", ADDLINK_CREATE_AND_OPEN ));
+  EXPECT_EQ(FAILED, tixiAddExternalLink( outDocumentHandle, parentPath, "TestData", NULL, ADDLINK_CREATE_AND_OPEN ));
+
+  EXPECT_EQ(ELEMENT_NOT_FOUND, tixiAddExternalLink( outDocumentHandle, "/invalidroot", "./", "externaldata-included-1.xml", ADDLINK_CREATE));
+
+  EXPECT_EQ(OPEN_FAILED, tixiAddExternalLink( outDocumentHandle, parentPath, "TestData", "this_file_does_not_exists.xml", ADDLINK_CREATE_AND_OPEN ));
 }
 
 TEST_F(OtherTests, usePrettyPrint)

--- a/tests/vector_check.cpp
+++ b/tests/vector_check.cpp
@@ -157,5 +157,6 @@ TEST(Vector, vectorToString)
 
     EXPECT_STREQ("0.00;1.00;2.00;3.00;4.00;5.00;6.00;7.00;8.00;9.00", myvecString);
 
+    free(myvecString);
     delete [] vec;
 }


### PR DESCRIPTION
This currently simply creates an external data node, filled with the path and filename.

The user specifies, whether the external files are directly loaded into the document, or whether the link is just created.

Closes #173