### PR TITLE
Added tixicpp target to install

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@
 add_library(tixicpp INTERFACE)
 target_include_directories(tixicpp INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/${TIXI_LIB_NAME}>
 )
 
 install(FILES
@@ -12,3 +12,6 @@ install(FILES
     DESTINATION include/${TIXI_LIB_NAME}
     COMPONENT headers
 )
+
+# this makes the tixicpp target also available by external libs
+install (TARGETS tixicpp EXPORT tixi3-targets COMPONENT headers)


### PR DESCRIPTION
Closes #166

I tested it with a local tigl build. It accepts the tixicpp target and also includes the correct directory.