### PR TITLE
Return zero, if xpath does not match

### DIFF
--- a/src/xpathFunctions.c
+++ b/src/xpathFunctions.c
@@ -44,11 +44,6 @@ xmlXPathObjectPtr XPathEvaluateExpression(TixiDocument* doc, const char* xPathEx
     return NULL;
   }
 
-  if (xmlXPathNodeSetIsEmpty(xpathObject->nodesetval)) {
-    xmlXPathFreeObject(xpathObject);
-    return NULL;
-  }
-
   XPathCacheInsert(doc->xpathCache, (const xmlChar*) xPathExpression, xpathObject);
 
   return xpathObject;
@@ -66,6 +61,10 @@ int XPathGetNodeNumber(TixiDocument* tixiDocument, const char* xPathExpression)
   xpathObject = XPathEvaluateExpression(tixiDocument, xPathExpression);
   if (xpathObject == NULL) {
     return -1;
+  }
+
+  if (xmlXPathNodeSetIsEmpty(xpathObject->nodesetval)) {
+      return 0;
   }
 
   nodes = xpathObject->nodesetval;

--- a/tests/xpath_check.cpp
+++ b/tests/xpath_check.cpp
@@ -56,10 +56,11 @@ TEST_F(XPathChecks, tixiXPathEvaluateNodeNumber)
   ASSERT_TRUE( num == 6 );
 }
 
-TEST_F(XPathChecks, tixiXPathEvaluateNodeNumber_fail)
+TEST_F(XPathChecks, tixiXPathEvaluateNodeNumber_noNodes)
 {
   int num = 0;
-  ASSERT_TRUE( tixiXPathEvaluateNodeNumber( documentHandle, "//@kruzifix", &num) == FAILED );
+  ASSERT_TRUE( tixiXPathEvaluateNodeNumber( documentHandle, "//@kruzifix", &num) == SUCCESS);
+  EXPECT_EQ(0, num);
 }
 
 


### PR DESCRIPTION
This fixed the issue , that an errpr is thrown, if no element match the xpath.

Caution: This somehow changes the behaviour of the API which might break user code. Can we merge this or better not?   

Maybe we should wait integrating this until tixi 3.3.0

Closes #198