### PR TITLE
Check for more errors in tixiUpdateTextElement

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -970,6 +970,25 @@ DLL_EXPORT ReturnCode tixiUpdateTextElement (const TixiDocumentHandle handle, co
   error = checkElement(document->xpathContext, elementPath, &element);
 
   if (!error) {
+    // from the documentation:
+    //   elementPath must refer to exactly one element which has only a text node and zero or more attributes but no further children with text nodes.
+
+    // we explicitly check for these errors as the operation has an undesired effect otherwise (e.g. only replacing the first part of the text)
+
+    if (element->type != XML_ELEMENT_NODE)
+      return NOT_AN_ELEMENT;
+
+    int nChilds = getChildNodeCount(element);
+    if (nChilds > 1) {
+      printMsg(MESSAGETYPE_ERROR, "Error: cannot update text of an element with multiple child nodes.\n");
+      return FAILED;
+    }
+
+    if (nChilds == 1 && (!xmlNodeIsText(element->children)) ) {
+      printMsg(MESSAGETYPE_ERROR, "Error: cannot update text of an element with a non-text child node.\n");
+      return FAILED;
+    }
+
     newElement = xmlNewText((xmlChar*) text);
     if(element->children) {
       xmlNodePtr nodeToReplace = element->children;


### PR DESCRIPTION
According to the documentation, `tixiUpdateTextElement` (and all related functions) should only work when the element path refers to a single element with no XML child nodes or at most one text child node.

This checks for some possible problems like elements with XML comments in the text.
Without this check, the code could remove a comment child and prepend to the text or only replace the first part of the text.
