### PR TITLE
Allow to get the text of comment() and text() through their xpath

### DIFF
--- a/src/xpathFunctions.c
+++ b/src/xpathFunctions.c
@@ -121,6 +121,9 @@ char* XPathExpressionGetText(TixiDocument* tixiDocument, const char* xPathExpres
       return NULL;
     }
   }
+  else if (cur->type == XML_TEXT_NODE || cur->type == XML_COMMENT_NODE) {
+    text = (char*) cur->content;
+  }
 
   return text;
 }

--- a/tests/TestData/xpathsEvaluate.xml
+++ b/tests/TestData/xpathsEvaluate.xml
@@ -8,4 +8,11 @@
     <b uID="a">Bla</b>
     <b uID="empty_element"/>
   </a>
+  <ugly_elem some_attr="x" some_other_attr="y">
+    <!-- some comment -->
+    some text
+    <another_element my_attr="hello"/>
+    <!-- more comments -->
+    even further text
+  </ugly_elem>
 </root>

--- a/tests/xpath_check.cpp
+++ b/tests/xpath_check.cpp
@@ -228,3 +228,51 @@ TEST_F(XPathChecks, tixiXPathExpressionGetXPath)
   ASSERT_EQ(INVALID_HANDLE, tixiXPathExpressionGetXPath(-1, "//a", 1, &xpath));
 }
 
+// get attribute text
+TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_attributes)
+{
+  int number = 0;
+  char* text = NULL;
+  char* path = NULL;
+
+  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/@*", &number);
+  ASSERT_EQ(2, number);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/@*", 1, &path);
+  ASSERT_STREQ("/root/ugly_elem/@some_attr", path);
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/@*", 1, &text);
+  ASSERT_STREQ("x", text);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/@*", 2, &path);
+  ASSERT_STREQ("/root/ugly_elem/@some_other_attr", path);
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/@*", 2, &text);
+  ASSERT_STREQ("y", text);
+}
+
+// get child nodes
+TEST_F(XPathChecks, tixiXPathGetXPath_ugly_elem)
+{
+  int number = 0;
+  char* path = NULL;
+
+  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/node()", &number);
+  ASSERT_EQ(6, number);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 1, &path);
+  ASSERT_STREQ("/root/ugly_elem/comment()[1]", path);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 2, &path);
+  ASSERT_STREQ("/root/ugly_elem/text()[1]", path);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 3, &path);
+  ASSERT_STREQ("/root/ugly_elem/another_element", path);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 4, &path);
+  ASSERT_STREQ("/root/ugly_elem/text()[2]", path);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 5, &path);
+  ASSERT_STREQ("/root/ugly_elem/comment()[2]", path);
+
+  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 6, &path);
+  ASSERT_STREQ("/root/ugly_elem/text()[3]", path);
+}

--- a/tests/xpath_check.cpp
+++ b/tests/xpath_check.cpp
@@ -276,3 +276,54 @@ TEST_F(XPathChecks, tixiXPathGetXPath_ugly_elem)
   tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 6, &path);
   ASSERT_STREQ("/root/ugly_elem/text()[3]", path);
 }
+
+// get text node text
+TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_textNode)
+{
+  int number = 0;
+  char* path = NULL;
+  char* text = NULL;
+
+  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/text()", &number);
+  ASSERT_EQ(3, number);
+
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 1, &text);
+  ASSERT_STREQ("\n    some text\n    ", text);
+
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 2, &text);
+  ASSERT_STREQ("\n    ", text);
+
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 3, &text);
+  ASSERT_STREQ("\n    even further text\n  ", text);
+}
+
+// get comment node text
+TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_commentNode)
+{
+  int number = 0;
+  char* path = NULL;
+  char* text = NULL;
+
+  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/comment()", &number);
+  ASSERT_EQ(2, number);
+
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/comment()", 1, &text);
+  ASSERT_STREQ(" some comment ", text);
+
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/comment()", 2, &text);
+  ASSERT_STREQ(" more comments ", text);
+}
+
+// get non-text element text
+TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_nontext_element)
+{
+  int number = 0;
+  char* path = NULL;
+  char* text = NULL;
+
+  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/another_element", &number);
+  ASSERT_EQ(1, number);
+
+  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/another_element", 1, &text);
+  ASSERT_EQ(NULL, text);
+}

--- a/tests/xpath_check.cpp
+++ b/tests/xpath_check.cpp
@@ -235,17 +235,17 @@ TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_attributes)
   char* text = NULL;
   char* path = NULL;
 
-  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/@*", &number);
+  ASSERT_EQ(SUCCESS, tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/@*", &number));
   ASSERT_EQ(2, number);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/@*", 1, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/@*", 1, &path));
   ASSERT_STREQ("/root/ugly_elem/@some_attr", path);
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/@*", 1, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/@*", 1, &text));
   ASSERT_STREQ("x", text);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/@*", 2, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/@*", 2, &path));
   ASSERT_STREQ("/root/ugly_elem/@some_other_attr", path);
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/@*", 2, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/@*", 2, &text));
   ASSERT_STREQ("y", text);
 }
 
@@ -255,25 +255,25 @@ TEST_F(XPathChecks, tixiXPathGetXPath_ugly_elem)
   int number = 0;
   char* path = NULL;
 
-  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/node()", &number);
+  ASSERT_EQ(SUCCESS, tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/node()", &number));
   ASSERT_EQ(6, number);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 1, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 1, &path));
   ASSERT_STREQ("/root/ugly_elem/comment()[1]", path);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 2, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 2, &path));
   ASSERT_STREQ("/root/ugly_elem/text()[1]", path);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 3, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 3, &path));
   ASSERT_STREQ("/root/ugly_elem/another_element", path);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 4, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 4, &path));
   ASSERT_STREQ("/root/ugly_elem/text()[2]", path);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 5, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 5, &path));
   ASSERT_STREQ("/root/ugly_elem/comment()[2]", path);
 
-  tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 6, &path);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetXPath(documentHandle, "/root/ugly_elem/node()", 6, &path));
   ASSERT_STREQ("/root/ugly_elem/text()[3]", path);
 }
 
@@ -284,16 +284,16 @@ TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_textNode)
   char* path = NULL;
   char* text = NULL;
 
-  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/text()", &number);
+  ASSERT_EQ(SUCCESS, tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/text()", &number));
   ASSERT_EQ(3, number);
 
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 1, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 1, &text));
   ASSERT_STREQ("\n    some text\n    ", text);
 
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 2, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 2, &text));
   ASSERT_STREQ("\n    ", text);
 
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 3, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/text()", 3, &text));
   ASSERT_STREQ("\n    even further text\n  ", text);
 }
 
@@ -304,13 +304,13 @@ TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_commentNode)
   char* path = NULL;
   char* text = NULL;
 
-  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/comment()", &number);
+  ASSERT_EQ(SUCCESS, tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/comment()", &number));
   ASSERT_EQ(2, number);
 
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/comment()", 1, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/comment()", 1, &text));
   ASSERT_STREQ(" some comment ", text);
 
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/comment()", 2, &text);
+  ASSERT_EQ(SUCCESS, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/comment()", 2, &text));
   ASSERT_STREQ(" more comments ", text);
 }
 
@@ -321,9 +321,9 @@ TEST_F(XPathChecks, tixiXPathExpressionGetTextByIndex_nontext_element)
   char* path = NULL;
   char* text = NULL;
 
-  tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/another_element", &number);
+  ASSERT_EQ(SUCCESS, tixiXPathEvaluateNodeNumber(documentHandle, "/root/ugly_elem/another_element", &number));
   ASSERT_EQ(1, number);
 
-  tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/another_element", 1, &text);
+  ASSERT_EQ(FAILED, tixiXPathExpressionGetTextByIndex(documentHandle, "/root/ugly_elem/another_element", 1, &text));
   ASSERT_EQ(NULL, text);
 }


### PR DESCRIPTION
Extend `tixiXPathExpressionGetTextByIndex` to return the textual content of comment and text nodes.

This allows to retrieve the complete "content" of an element with text and comments if you're really want it.
All other methods like `tixiGetTextElement` filter out comments (which seems the right thing to do).