### PR TITLE
Invalidate XPath cache in tixiImportElementFromString

### DIFF
--- a/src/tixiImpl.c
+++ b/src/tixiImpl.c
@@ -3204,6 +3204,10 @@ DLL_EXPORT ReturnCode tixiImportElementFromString (const TixiDocumentHandle hand
     parseErrors = xmlParseInNodeContext(parentElement, xmlImportString, strlen(xmlImportString), 0, &newElement);
 
     if (!parseErrors) {
+
+      // structure change!, we have to empty the xpath cache
+      XPathClearCache(document->xpathCache);
+
       xmlAddChild(parentElement, newElement);
     }
     else {

--- a/tests/import_element_check.cpp
+++ b/tests/import_element_check.cpp
@@ -83,3 +83,20 @@ TEST_F(ImportElementsCheck, notWellFormed)
     ASSERT_EQ(NOT_WELL_FORMED, tixiImportElementFromString(handle, "/root/a", "sdaf<||/sdfasf>"));
 }
 
+TEST_F(ImportElementsCheck, invalidateXPathCache)
+{
+    char* text = NULL;
+    int num = 0;
+    char* path = NULL;
+
+    ASSERT_TRUE( tixiSetCacheEnabled(handle, true) == SUCCESS );
+
+    ASSERT_TRUE( tixiXPathEvaluateNodeNumber(handle, "//*", &num) == SUCCESS );
+    ASSERT_EQ(3, num);
+
+    ASSERT_EQ(SUCCESS, tixiImportElementFromString(handle, "/root", "<a attr=\"hello\"><x/></a>"));
+
+    ASSERT_TRUE( tixiXPathEvaluateNodeNumber(handle, "//*", &num) == SUCCESS );
+    ASSERT_EQ(5, num);
+}
+


### PR DESCRIPTION
Small bugfix: XPath cache was not cleared in function that modifies the xml tree.