### PR TITLE
Support for the conan package manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y cmake cmake-data gfortran libcurl4-openssl-dev libxslt1-dev
+          sudo apt-get install -y cmake cmake-data gfortran libcurl4-openssl-dev libxslt1-dev python3-setuptools
+          sudo python3 -m pip install conan
       - name: Build TiXI
         run: |
           mkdir build
@@ -39,6 +40,9 @@ jobs:
           name: build-${{ matrix.os }}-${{ matrix.config }}
           path: build
           retention-days: 1
+      - name: Build conan package
+        run: |
+          conan create . -o tixi3:shared=True
 
   build-win64:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           retention-days: 1
       - name: Build conan package
         run: |
-          conan create . -o tixi3:shared=True
+          conan create . -o tixi3:shared=True -s build_type=${{ matrix.config }}
 
   build-win64:
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required (VERSION 3.1)
 
+if (EXISTS ${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
+    cmake_policy(SET CMP0091 NEW)
+    include(${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
+endif()
+
 # Set a default build type if none was specified
 if(NOT DEFINED CMAKE_BUILD_TYPE)
     message(STATUS "Setting build type to 'Release' as none was specified.")

--- a/bindings/matlab/make_tixi_matlab.py
+++ b/bindings/matlab/make_tixi_matlab.py
@@ -23,8 +23,10 @@ if __name__ == '__main__':
     #ann =   CP.Annotation('#annotate out: 3, 4A(3)')  
 
     # copy handwritten *.m files into current directory
-    for mfile in glob.glob(filepath + r'/*.m'):
-        shutil.copy(mfile, '.')
+    # only if source directory != binary directory
+    if os.path.abspath(filepath) != os.path.abspath("."):
+        for mfile in glob.glob(filepath + r'/*.m'):
+            shutil.copy(mfile, '.')
     
     parser = CP.CHeaderFileParser()
     

--- a/cmake/FindCURL.cmake
+++ b/cmake/FindCURL.cmake
@@ -5,6 +5,8 @@
 #  CURL_LIBRARIES      - List of libraries when using curl.
 #  CURL_FOUND          - True if curl found.
 #  CURL_VERSION_STRING - the version of curl found (since CMake 2.8.8)
+#
+# Creates the CMake target CURL::libcurl for the curl library
 
 #=============================================================================
 # Copyright 2006-2009 Kitware, Inc.
@@ -57,8 +59,8 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(CURL
                                   VERSION_VAR CURL_VERSION_STRING)
 
 if(CURL_FOUND)
-  add_library(curllib UNKNOWN IMPORTED)
-  set_target_properties(curllib PROPERTIES
+  add_library(CURL::libcurl UNKNOWN IMPORTED)
+  set_target_properties(CURL::libcurl PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES ${CURL_INCLUDE_DIR}
       IMPORTED_LOCATION ${CURL_LIBRARY}
       IMPORTED_IMPLIB ${CURL_LIBRARY}
@@ -66,7 +68,7 @@ if(CURL_FOUND)
   if (WIN32)
     string(REGEX MATCH "_a.lib$" CURL_STATICLIB ${CURL_LIBRARY})
     if (CURL_STATICLIB)
-      set_target_properties(curllib
+      set_target_properties(CURL::libcurl
           PROPERTIES INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB"
       )
     endif(CURL_STATICLIB)

--- a/cmake/tixi-config.cmake.in
+++ b/cmake/tixi-config.cmake.in
@@ -31,9 +31,9 @@ if(NOT "$<TARGET_PROPERTY:tixi3,TYPE>" STREQUAL "SHARED_LIBRARY")
     set_property(TARGET LibXslt::LibXslt APPEND PROPERTY IMPORTED_LOCATION "${LIBXSLT_LIBRARIES}")
   endif()
   
-  if(CURL_FOUND AND NOT TARGET curllib)
-    add_library(curllib UNKNOWN IMPORTED)
-    set_target_properties(curllib PROPERTIES
+  if(CURL_FOUND AND NOT TARGET CURL::libcurl)
+    add_library(CURL::libcurl UNKNOWN IMPORTED)
+    set_target_properties(CURL::libcurl PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES ${CURL_INCLUDE_DIR}
       IMPORTED_LOCATION ${CURL_LIBRARY}
       IMPORTED_IMPLIB ${CURL_LIBRARY}
@@ -41,7 +41,7 @@ if(NOT "$<TARGET_PROPERTY:tixi3,TYPE>" STREQUAL "SHARED_LIBRARY")
     if (WIN32)
       string(REGEX MATCH "_a.lib$" CURL_STATICLIB ${CURL_LIBRARY})
       if (CURL_STATICLIB)
-        set_target_properties(curllib
+        set_target_properties(CURL::libcurl
           PROPERTIES INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB"
       )
       endif(CURL_STATICLIB)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,8 @@
-from conan.tools.cmake import CMake
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools import files
 from conan import ConanFile
 import os, re
+import textwrap
 
 required_conan_version = ">=1.45.0"
 
@@ -49,13 +50,19 @@ class Tixi3Conan(ConanFile):
         "fPIC": True,
     }
 
-    source_subfolder = "."
-    generators = ["CMakeDeps", "CMakeToolchain"]
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def requirements(self):
         self.requires("libxml2/2.9.14")
         self.requires("libxslt/1.1.34")
         self.requires("libcurl/7.84.0")
+
+    def layout(self):
+        cmake_layout(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -63,43 +70,71 @@ class Tixi3Conan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
 
         # tixi is a c library
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def export_sources(self):
         self.output.info("Executing export_sources() method")
-        self.copy("*", dst=self.source_subfolder)
+        self.copy("*", dst=self.export_sources_folder)
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder=self.source_subfolder)
+        cmake.configure()
         cmake.build()
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        files.save(self, module_file, content)
 
     def package(self):
         cmake = CMake(self)
         cmake.install()
 
-        # remove package generated cmake config files
-        files.rmdir(self, 
-            os.path.join(self.package_folder, "lib", "tixi3"))
-
-        # copy the LICENSE file
-        self.copy("LICENSE", dst="licenses", src=self.source_subfolder)
-
-        # remove share directory, which only contains documentation,
-        # expamples...
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "tixi3"))
+        files.copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         files.rmdir(self, os.path.join(self.package_folder, "share"))
 
+        # provide alias target tixi3 for v1 packages
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"tixi3": "tixi3::tixi3"}
+        )
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", "conan-official-{}-targets.cmake".format(self.name))
+
+
     def package_info(self):
-        self.cpp_info.includedirs = ['include/tixi3']
+        self.cpp_info.includedirs.append(os.path.join("include", "tixi3"))
         self.cpp_info.libs = ['tixi3']
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ['Shlwapi']
 
-        self.cpp_info.set_property("cmake_target_aliases", ["tixi3"])
-        self.cpp_info.libdirs = ['lib']
-        self.cpp_info.bindirs = ['bin']
+        self.cpp_info.set_property("cmake_file_name", "tixi3")
+        self.cpp_info.set_property("cmake_target_name", "tixi3")
+
+        # provide alias target tixi3 for v1 packages
+        self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/conanfile.py
+++ b/conanfile.py
@@ -126,7 +126,11 @@ class Tixi3Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(os.path.join("include", "tixi3"))
-        self.cpp_info.libs = ['tixi3']
+        
+        if self.settings.build_type != "Debug":
+            self.cpp_info.libs = ['tixi3']
+        else:
+            self.cpp_info.libs = ['tixi3-d']
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ['Shlwapi']

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,105 @@
+from conan.tools.cmake import CMake
+from conan.tools import files
+from conan import ConanFile
+import os, re
+
+required_conan_version = ">=1.45.0"
+
+def get_version_from_cmakelists():
+    if not os.path.exists("CMakeLists.txt"):
+        return None
+    
+    major_ver = "0"
+    minor_ver = "0"
+    patch_ver = "0"
+    
+    with open("CMakeLists.txt","r") as file_one:
+        major_re = re.compile('set\(TIXI_VERSION_MAJOR ([0-9]+)\)')
+        minor_re = re.compile('set\(TIXI_VERSION_MINOR ([0-9]+)\)')
+        patch_re = re.compile('set\(TIXI_VERSION_PATCH ([0-9]+(-[a-z, A_Z, 0-9]+)?)\)')
+        for line in file_one:
+            m = major_re.match(line)
+            if m:
+                major_ver = m.group(1)
+            m = minor_re.match(line)
+            if m:
+                minor_ver = m.group(1)
+            m = patch_re.match(line)
+            if m:
+                patch_ver = m.group(1)
+
+    return "%s.%s.%s" % (major_ver, minor_ver, patch_ver)
+
+class Tixi3Conan(ConanFile):
+    name = "tixi3"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "A simple xml interface based on libxml2 and libxslt"
+    topics = ("tixi3", "xml")
+    homepage = "https://github.com/DLR-SC/tixi"
+    license = "Apache-2.0"
+    version = get_version_from_cmakelists()
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    source_subfolder = "."
+    generators = ["CMakeDeps", "CMakeToolchain"]
+
+    def requirements(self):
+        self.requires("libxml2/2.9.14")
+        self.requires("libxslt/1.1.34")
+        self.requires("libcurl/7.84.0")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+        # tixi is a c library
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def export_sources(self):
+        self.output.info("Executing export_sources() method")
+        self.copy("*", dst=self.source_subfolder)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self.source_subfolder)
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        # remove package generated cmake config files
+        files.rmdir(self, 
+            os.path.join(self.package_folder, "lib", "tixi3"))
+
+        # copy the LICENSE file
+        self.copy("LICENSE", dst="licenses", src=self.source_subfolder)
+
+        # remove share directory, which only contains documentation,
+        # expamples...
+        files.rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = ['include/tixi3']
+        self.cpp_info.libs = ['tixi3']
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ['Shlwapi']
+
+        self.cpp_info.set_property("cmake_target_aliases", ["tixi3"])
+        self.cpp_info.libdirs = ['lib']
+        self.cpp_info.bindirs = ['bin']

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fmessage-length=0")
 endif()
 
-set(TIXI_LIBS curllib LibXslt::LibXslt LibXml2::LibXml2)
+set(TIXI_LIBS CURL::libcurl LibXslt::LibXslt LibXml2::LibXml2)
 if(WIN32)
     set(TIXI_LIBS ${TIXI_LIBS} Shlwapi)
 endif(WIN32)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(Tixi-Conan-TestPackage)
+
+find_package(tixi3 REQUIRED)
+
+add_executable(tixi3_conan_test ../examples/Demo/tixiDemo.c)
+target_link_libraries(tixi3_conan_test PRIVATE tixi3::tixi3)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
-project(Tixi-Conan-TestPackage)
+project(Tixi-Conan-TestPackage C)
 
 find_package(tixi3 REQUIRED)
 
 add_executable(tixi3_conan_test ../examples/Demo/tixiDemo.c)
-target_link_libraries(tixi3_conan_test PRIVATE tixi3::tixi3)
+target_link_libraries(tixi3_conan_test PRIVATE tixi3)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,23 @@
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "virtualenv"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "tixi3_conan_test")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
This PR adds support for the conan package manager.

The conanfile can be used to install the thirdparty dependencies and to create a tixi conan package.

# Using conan to install dependencies # 

The build process is slightly changed, by using `conan install` before calling cmake.

    mkdir build && cd build
    conan install .. -o shared=True
    cmake ..
    make

The argument `shared` specifies, whether tixi is built as a shared library or not.

# Create the conan package # 

Simply call

    conan create .

from the source directory.

# Adaptations to the current code # 
 - `make_tixi_matlab.py`: Allows to create in-source builds
 - `CMakeLists.txt`: Actually not required, but automatically loads the conan config, if created.
 - `FindCURL.cmake` and `cmake/tixi-config.cmake.in`: Our FindCURL module used different target names incompatible to the official targets (https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindCURL.cmake#L26) and the conan targets. Hence, a renaming was required.

## Note ##
A pull request to the conan package index to add tixi is ongoing:
https://github.com/conan-io/conan-center-index/pull/12610

The package recipe is slightly changed, since it needs to pull the sources from github first.

Closes #213 