### PR TITLE
CI: Fix conan install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           md c:\tixi-3rdparty -Force | Out-Null
           If (!(Test-Path -Path "c:\tixi-3rdparty\tixi-3rdparty-vc2015-win64")) {
             Write-Output "Downloading tixi 3rdparty libraries"
-            (new-object System.Net.WebClient).Downloadfile("https://sourceforge.net/projects/tixi/files/dev-tools/tixi-3rdparty-vc2015-win64.zip", "c:\tixi-3rdparty-vc2015-win64.zip")
+            Invoke-WebRequest -Uri "https://sourceforge.net/projects/tixi/files/dev-tools/tixi-3rdparty-vc2015-win64.zip" -OutFile "c:\tixi-3rdparty-vc2015-win64.zip"
             Write-Output "Extract tixi 3rdparty libraries"
             & 7z x -y "c:\tixi-3rdparty-vc2015-win64.zip" -oC:\tixi-3rdparty\ > null
           }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y cmake cmake-data gfortran libcurl4-openssl-dev libxslt1-dev python3-setuptools
-          sudo pip3 install conan
+          pip3 install --user conan
+          source ~/.profile
       - name: Build TiXI
         run: |
           mkdir build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,13 +69,13 @@ jobs:
           md c:\tixi-3rdparty -Force | Out-Null
           If (!(Test-Path -Path "c:\tixi-3rdparty\tixi-3rdparty-vc2015-win64")) {
             Write-Output "Downloading tixi 3rdparty libraries"
-            Invoke-WebRequest -Uri "https://sourceforge.net/projects/tixi/files/dev-tools/tixi-3rdparty-vc2015-win64.zip" -OutFile "c:\tixi-3rdparty-vc2015-win64.zip"
+            Invoke-WebRequest -UserAgent "Wget" -Uri "https://sourceforge.net/projects/tixi/files/dev-tools/tixi-3rdparty-vc2015-win64.zip" -OutFile "c:\tixi-3rdparty-vc2015-win64.zip"
             Write-Output "Extract tixi 3rdparty libraries"
             & 7z x -y "c:\tixi-3rdparty-vc2015-win64.zip" -oC:\tixi-3rdparty\ > null
           }
           If (!(Test-Path -Path "c:\tixi-3rdparty\matlab-libs-win")) {
             Write-Output "Downloading matlab libraries"
-            Invoke-WebRequest -Uri "https://sourceforge.net/projects/tixi/files/dev-tools/matlab-libs-win.zip" -OutFile "c:\matlab-libs-win.zip"
+            Invoke-WebRequest -UserAgent "Wget" -Uri "https://sourceforge.net/projects/tixi/files/dev-tools/matlab-libs-win.zip" -OutFile "c:\matlab-libs-win.zip"
             Write-Output "Extract matlab libraries"
             & 7z x -y "c:\matlab-libs-win.zip" -oC:\tixi-3rdparty\ > null
           }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           }
           If (!(Test-Path -Path "c:\tixi-3rdparty\matlab-libs-win")) {
             Write-Output "Downloading matlab libraries"
-            (new-object System.Net.WebClient).Downloadfile("https://sourceforge.net/projects/tixi/files/dev-tools/matlab-libs-win.zip", "c:\matlab-libs-win.zip")
+            Invoke-WebRequest -Uri "https://sourceforge.net/projects/tixi/files/dev-tools/matlab-libs-win.zip" -OutFile "c:\matlab-libs-win.zip"
             Write-Output "Extract matlab libraries"
             & 7z x -y "c:\matlab-libs-win.zip" -oC:\tixi-3rdparty\ > null
           }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y cmake cmake-data gfortran libcurl4-openssl-dev libxslt1-dev python3-setuptools
-          sudo python3 -m pip install conan
+          sudo pip3 install conan
       - name: Build TiXI
         run: |
           mkdir build

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,7 +58,7 @@ class Tixi3Conan(ConanFile):
 
     def requirements(self):
         self.requires("libxml2/[>=2.12.5 <3]")
-        self.requires("libxslt/1.1.39")
+        self.requires("libxslt/1.1.42")
         self.requires("libcurl/[>=7.78.0 <9]")
 
     def layout(self):


### PR DESCRIPTION
Fixes #232

Following issues are fixed:
 - pip failed to install conan on github hosted runner for some reason. Resolved by installing with pip3 install --user and immediatly sourcing `~/.profile`.
 - conan recipe has a libxml2 version conflict due to a downstream dependency. Fixed by bumping libxslt.
 - Download from sourceforge failed in CI from Powershell