### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,13 @@ name: CI
 on:
   schedule:
     - cron: "20 3 * * 2"
-  push:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    branches:
+      - 'master'
+    tags:
+      - v*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         config: ["Debug", "Release"]
-        os: ["windows-2019", "windows-latest"]
+        os: ["windows-2022", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
 # On the Github-hosted runner, git checks out text files with \r\n (I think)
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         config: ["Debug", "Release"]
-        os: ["windows-2019", "windows-latest"]
+        os: ["windows-2022", "windows-latest"]
     runs-on: ${{ matrix.os }}
     needs: build-win64
     steps:
@@ -150,7 +150,7 @@ jobs:
           .\${{ matrix.config }}\TIXI-unittests.exe --gtest_output=xml:test_results.xml
 
   deploy-win64:
-    runs-on: "windows-2019"
+    runs-on: "windows-2022"
     needs: test-win64
     steps:
       - uses: actions/checkout@v4
@@ -159,7 +159,7 @@ jobs:
       - name: Download build directory
         uses: actions/download-artifact@v4
         with:
-          name: build-windows-2019-Release
+          name: build-windows-2022-Release
           path: build
       - name: Artifact installer and zip
         run: |


### PR DESCRIPTION
 - Remove deprecated Windows runner
 - Change workflow triggers. Previously every commit in an open PR triggered the workflow twice, because the workflow triggers were for commit AND PR. Now we only trigger the workflow for commits and tags on the master branch and for updates in a PR. So for non-PR branches, CI doesn't run.